### PR TITLE
Publish index docker image to ghcr

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -1,0 +1,26 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [ published ]
+
+jobs:
+  push_to_registry:
+    name: Push container image to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: push-to-ghcr
+        uses: macbre/push-to-ghcr@v14
+        with:
+          image_name: ${{ github.repository }}  
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - publish-to-ghcr # TODO: delete before merge
   release:
     types: [ published ]
 

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -1,9 +1,6 @@
 name: Publish container image
 
 on:
-  push:
-    branches:
-      - main
   release:
     types: [ published ]
 

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -1,10 +1,9 @@
-name: Publish Docker image
+name: Publish container image
 
 on:
   push:
     branches:
       - main
-      - publish-to-ghcr # TODO: delete before merge
   release:
     types: [ published ]
 


### PR DESCRIPTION
Changes:
* adds a new workflow that builds and publishes the container image


Details:
Images will be published to `ghcr.io/arcadia-solutions/arcadia`. If the build is triggered off a merge to main, it will be tagged with the merge commit SHA. If the build is triggered off of a Github release, it will have the version number, e.g. 1.2 for v1.2

Here is test example from my fork: https://github.com/bees/arcadia-index/actions/runs/14477483681