### PR TITLE
Make workflows run conditionally

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,4 +1,4 @@
-name: running build
+name: backend jobs
 
 on:
   push:
@@ -7,12 +7,15 @@ on:
   pull_request:
     branches:
       - main
+    paths: # comment this out if you are updating actions
+      - 'backend/**'
 
 env:
   CARGO_TERM_COLOR: always
 
+
 jobs:
-  build-backend:
+  build:
     runs-on: ubuntu-latest
     container: rust:1.86-bullseye
     defaults:
@@ -49,22 +52,3 @@ jobs:
     - name: Ensure schema and query metadata are in sync
       run: cargo sqlx prepare --check
 
-  lint-format-frontend:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./frontend
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Setup
-      uses: actions/setup-node@v4
-      with:
-        node-version: 22
-        cache: 'npm'
-        cache-dependency-path: frontend/package-lock.json
-
-    - run: npm ci
-    - run: npm run lint
-    - run: npm run check-format
-    

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -36,8 +36,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+    - name: Install Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain
 
     - name: Setup env
       run: cp -f .env.ci .env

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -17,7 +17,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: rust:1.86-bullseye
     defaults:
       run:
         working-directory: ./backend
@@ -36,6 +35,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Install rust toolchain
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Setup env
       run: cp -f .env.ci .env

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,4 +1,4 @@
-name: backend jobs
+name: Backend CI
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - main
-    paths: # comment this out if you are updating actions
+    paths: # comment this section out if you are updating actions
       - 'backend/**'
 
 env:
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: setup env
+    - name: Setup env
       run: cp -f .env.ci .env
 
     - name: Build
@@ -46,7 +46,7 @@ jobs:
     - name: Run tests
       run: cargo test
 
-    - name: install sqlx
+    - name: Install sqlx
       run: cargo install sqlx-cli
 
     - name: Ensure schema and query metadata are in sync

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - main
-    paths: # comment this section out if you are updating actions
+    paths:
       - 'backend/**'
 
 env:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - run: git diff --name-status  -- path/to/directory/
-
     - name: Setup
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,34 @@
+name: frontend jobs
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths: # comment this out if you are updating actions and need to test
+      - 'frontend/**'
+
+jobs:
+  check-lint-format:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+    steps:
+    - uses: actions/checkout@v4
+
+    - run: git diff --name-status  -- path/to/directory/
+
+    - name: Setup
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
+
+    - run: npm ci
+    - run: npm run lint
+    - run: npm run check-format
+    

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - main
-    paths: # comment this section out if you are updating actions and need to test
+    paths:
       - 'frontend/**'
 
 jobs:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,4 +1,4 @@
-name: frontend jobs
+name: Frontend CI
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - main
-    paths: # comment this out if you are updating actions and need to test
+    paths: # comment this section out if you are updating actions and need to test
       - 'frontend/**'
 
 jobs:

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -1,4 +1,4 @@
-name: Publish container image
+name: publish container image
 
 on:
   release:

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -1,4 +1,4 @@
-name: publish container image
+name: Publish container image
 
 on:
   release:


### PR DESCRIPTION
Changes:
* splits the ci.yml file into two specific FE/BE workflows
* Use [paths](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) to only run the workflows when the subdirectory changes

Goal is to avoid unnecessary work. I originally kept everything in one file and tried to parse the diff but it was brittle - this is a lot more straightforward approach.