### PR TITLE
backend: make clippy green

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -39,6 +39,11 @@ jobs:
 
     - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: clippy
+
+    - name: Check clippy for new warnings
+      run: cargo clippy
 
     - name: Setup env
       run: cp -f .env.ci .env

--- a/backend/migrations/20250312215600_initdb.sql
+++ b/backend/migrations/20250312215600_initdb.sql
@@ -122,7 +122,6 @@ CREATE TYPE category_enum AS ENUM (
     'Soundtrack',
     'Anthology',
     'Compilation',
-    'SingleCategory',
     'Remix',
     'Bootleg',
     'Mixtape',

--- a/backend/src/handlers/scrapers/tmdb.rs
+++ b/backend/src/handlers/scrapers/tmdb.rs
@@ -77,7 +77,7 @@ struct Tmdb {
     config: Configuration,
 }
 
-const BASE_URL: &'static str = "https://api.themoviedb.org/3";
+const BASE_URL: &str = "https://api.themoviedb.org/3";
 
 impl Tmdb {
     async fn new(bearer: impl Into<String>) -> Result<Self> {

--- a/backend/src/handlers/torrent_handler.rs
+++ b/backend/src/handlers/torrent_handler.rs
@@ -65,7 +65,7 @@ pub async fn download_dottorrent_file(
         return Err(Error::DottorrentFileNotFound);
     }
 
-    actix_files::NamedFile::open(&file_path).map_err(|_| Error::DottorrentFileNotFound)
+    actix_files::NamedFile::open(file_path).map_err(|_| Error::DottorrentFileNotFound)
 }
 
 #[utoipa::path(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -6,7 +6,6 @@ mod tracker;
 
 use actix_cors::Cors;
 use actix_web::{App, HttpServer, middleware, web::Data};
-use dotenvy;
 use reqwest::Url;
 use routes::init;
 use sqlx::postgres::PgPoolOptions;
@@ -52,7 +51,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(cors)
             .app_data(Data::new(Arcadia {
                 pool: pool.clone(),
-                open_signups: open_signups,
+                open_signups,
                 dottorrent_files_path: PathBuf::from(&dottorrent_files_path),
                 frontend_url: Url::from_str(&frontend_url)
                     .expect("ARCADIA_FRONTEND_URL env var malformed"),

--- a/backend/src/models/edition_group.rs
+++ b/backend/src/models/edition_group.rs
@@ -9,24 +9,33 @@ use super::torrent::LiteTorrent;
 #[derive(Debug, Serialize, Deserialize, ToSchema, sqlx::Type)]
 #[sqlx(type_name = "source_enum")]
 pub enum Source {
-    CD,
-    DVD5,
-    DVD9,
+    #[sqlx(rename = "CD")]
+    Cd,
+    #[sqlx(rename = "DVD5")]
+    Dvd5,
+    #[sqlx(rename = "DVD9")]
+    Dvd9,
     Vinyl,
     Web,
     Soundboard,
-    SACD,
-    DAT,
+    #[sqlx(rename = "SACD")]
+    Sacd,
+    #[sqlx(rename = "DAT")]
+    Dat,
     Cassette,
     #[sqlx(rename = "Blu-Ray")]
     BluRay,
     LaserDisc,
     #[sqlx(rename = "HD-DVD")]
-    HDDVD,
-    HDTV,
-    PDTV,
-    TV,
-    VHS,
+    Hddvd,
+    #[sqlx(rename = "HDTV")]
+    Hdtv,
+    #[sqlx(rename = "PDTV")]
+    Pdtv,
+    #[sqlx(rename = "TV")]
+    Tv,
+    #[sqlx(rename = "VHS")]
+    Vhs,
     Mixed,
     #[sqlx(rename = "Physical-Book")]
     PhysicalBook,

--- a/backend/src/models/title_group.rs
+++ b/backend/src/models/title_group.rs
@@ -31,8 +31,6 @@ pub enum Category {
     Soundtrack,
     Anthology,
     Compilation,
-    #[sqlx(rename = "Single")]
-    SingleCategory,
     Remix,
     Bootleg,
     Mixtape,

--- a/backend/src/models/torrent.rs
+++ b/backend/src/models/torrent.rs
@@ -82,8 +82,10 @@ pub enum VideoCodec {
 #[derive(Debug, Deserialize, Serialize, sqlx::Type, ToSchema)]
 #[sqlx(type_name = "features_enum")]
 pub enum Features {
-    HDR,
-    DV,
+    #[sqlx(rename = "HDR")]
+    Hdr,
+    #[sqlx(rename = "DV")]
+    Dv,
     Commentary,
     Remux,
     #[sqlx(rename = "3D")]
@@ -91,13 +93,14 @@ pub enum Features {
     Booklet,
     Cue,
 }
+
 impl FromStr for Features {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "HDR" => Ok(Features::HDR),
-            "DV" => Ok(Features::DV),
+            "HDR" => Ok(Features::Hdr),
+            "DV" => Ok(Features::Dv),
             "Commentary" => Ok(Features::Commentary),
             "Remux" => Ok(Features::Remux),
             "3D" => Ok(Features::ThreeD),

--- a/backend/src/repositories/edition_group_repository.rs
+++ b/backend/src/repositories/edition_group_repository.rs
@@ -19,10 +19,10 @@ pub async fn create_edition_group(
     "#;
 
     let created_edition_group = sqlx::query_as::<_, EditionGroup>(CREATE_EDITION_GROUPS_QUERY)
-        .bind(&edition_group_form.title_group_id)
+        .bind(edition_group_form.title_group_id)
         .bind(&edition_group_form.name)
-        .bind(&edition_group_form.release_date)
-        .bind(&current_user.id)
+        .bind(edition_group_form.release_date)
+        .bind(current_user.id)
         .bind(&edition_group_form.description)
         .bind(&edition_group_form.distributor)
         .bind(&edition_group_form.covers)

--- a/backend/src/repositories/title_group_repository.rs
+++ b/backend/src/repositories/title_group_repository.rs
@@ -20,10 +20,10 @@ pub async fn create_title_group(
     "#;
 
     let created_title_group = sqlx::query_as::<_, TitleGroup>(create_title_group_query)
-        .bind(&title_group_form.master_group_id)
+        .bind(title_group_form.master_group_id)
         .bind(&title_group_form.name)
         .bind(&title_group_form.name_aliases)
-        .bind(&current_user.id)
+        .bind(current_user.id)
         .bind(&title_group_form.description)
         .bind(&title_group_form.original_language)
         .bind(&title_group_form.country_from)
@@ -32,7 +32,7 @@ pub async fn create_title_group(
         .bind(&title_group_form.embedded_links)
         .bind(&title_group_form.category)
         .bind(&title_group_form.content_type)
-        .bind(&title_group_form.original_release_date)
+        .bind(title_group_form.original_release_date)
         .bind(&title_group_form.tags)
         .bind(&title_group_form.tagline)
         // .bind(&title_group_form.public_ratings)

--- a/backend/src/repositories/torrent_request_repository.rs
+++ b/backend/src/repositories/torrent_request_repository.rs
@@ -24,8 +24,8 @@ pub async fn create_torrent_request(
     "#;
 
     let created_torrent_request = sqlx::query_as::<_, TorrentRequest>(create_torrent_request_query)
-        .bind(&torrent_request.title_group_id)
-        .bind(&current_user.id)
+        .bind(torrent_request.title_group_id)
+        .bind(current_user.id)
         .bind(&torrent_request.edition_name)
         .bind(&torrent_request.release_group)
         .bind(&torrent_request.description)
@@ -37,8 +37,8 @@ pub async fn create_torrent_request(
         .bind(&torrent_request.features)
         .bind(&torrent_request.subtitle_languages)
         .bind(&torrent_request.video_resolution)
-        .bind(&torrent_request.bounty_upload)
-        .bind(&torrent_request.bounty_bonus_points)
+        .bind(torrent_request.bounty_upload)
+        .bind(torrent_request.bounty_bonus_points)
         .fetch_one(pool)
         .await
         .map_err(Error::CouldNotCreateTorrentRequest)?;

--- a/backend/src/tracker/announce.rs
+++ b/backend/src/tracker/announce.rs
@@ -231,7 +231,7 @@ impl Serialize for PeerCompact {
 
 struct BytesVisitor;
 
-impl<'de> serde::de::Visitor<'de> for BytesVisitor {
+impl serde::de::Visitor<'_> for BytesVisitor {
     type Value = PeerCompact;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {


### PR DESCRIPTION
Clippy is a rust tool that does some basic static analysis.  Run it, and ensure that the backend comes out error and warning free.

In the process, this identified that the `category_enum` had both `Single` and `SingleCategory` members, but on the backend, they were being aliased.  Just opt to drop the latter.

Also, ensure clippy will run in CI.