### PR TITLE
Optimize CI workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -75,12 +75,12 @@ jobs:
 
       - name: Build
         run: cargo build
-        env:
+        # env:
         #  SQLX_OFFLINE: "true"
   
       - name: Run tests
         run: cargo test
-        env:
+        # env:
         #  SQLX_OFFLINE: "true"
 
       - name: Install sqlx

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -18,45 +18,6 @@ env:
 
 jobs:
 
-  build:
-    runs-on: ubuntu-latest
-    container: rust:1.86-bullseye
-    services:
-      arcadiadb:
-        image: postgres
-        env:
-          POSTGRES_USER: arcadia
-          POSTGRES_PASSWORD: password
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    defaults:
-      run:
-        working-directory: ./backend
-    
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          cache-workspaces: ./backend
-      
-      - name: Build
-        run: cargo build
-        env:
-          SQLX_OFFLINE: "true"
-  
-      - name: Run tests
-        run: cargo test
-        env:
-          SQLX_OFFLINE: "true"
-
   lint:
     runs-on: ubuntu-latest
 
@@ -72,14 +33,14 @@ jobs:
         with:
           components: clippy
           cache-workspaces: ./backend
+          cache-on-failure: true
   
       - name: Check clippy for new warnings
         run: cargo clippy
         env:
           SQLX_OFFLINE: "true"
   
-
-  schema-check:
+  build-schema-check:
     runs-on: ubuntu-latest
     container: rust:1.86-bullseye
     defaults:
@@ -107,9 +68,20 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: ./backend
+          cache-on-failure: true
 
       - name: Setup env
         run: cp -f .env.ci .env
+
+      - name: Build
+        run: cargo build
+        env:
+        #  SQLX_OFFLINE: "true"
+  
+      - name: Run tests
+        run: cargo test
+        env:
+        #  SQLX_OFFLINE: "true"
 
       - name: Install sqlx
         run: cargo install sqlx-cli

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -4,20 +4,63 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'backend/**'
+      - '.github/workflows/backend.yml'
 
 env:
   CARGO_TERM_COLOR: always
 
 
 jobs:
+
   build:
     runs-on: ubuntu-latest
-    container: rust:1.86-bullseye
+
+    defaults:
+      run:
+        working-directory: ./backend
+    
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      
+      - name: Build
+        run: cargo build
+  
+      - name: Run tests
+        run: cargo test
+
+  lint:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./backend
+    
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
+  
+      - name: Check clippy for new warnings
+        run: cargo clippy
+  
+
+  schema-check:
+    runs-on: ubuntu-latest
+    # container: rust:1.86-bullseye
     defaults:
       run:
         working-directory: ./backend
@@ -28,6 +71,8 @@ jobs:
         env:
           POSTGRES_USER: arcadia
           POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -35,28 +80,17 @@ jobs:
           --health-retries 5
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install Rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        components: clippy
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
-    - name: Check clippy for new warnings
-      run: cargo clippy
+      - name: Setup env
+        run: cp -f .env.ci .env
 
-    - name: Setup env
-      run: cp -f .env.ci .env
+      - name: Install sqlx
+        run: cargo install sqlx-cli
 
-    - name: Build
-      run: cargo build
-
-    - name: Run tests
-      run: cargo test
-
-    - name: Install sqlx
-      run: cargo install sqlx-cli
-
-    - name: Ensure schema and query metadata are in sync
-      run: cargo sqlx prepare --check
+      - name: Ensure schema and query metadata are in sync
+        run: cargo sqlx prepare --check
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-workspaces: ./backend
       
       - name: Build
         run: cargo build
@@ -51,6 +53,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
+          cache-workspaces: ./backend
   
       - name: Check clippy for new warnings
         run: cargo clippy
@@ -58,7 +61,7 @@ jobs:
 
   schema-check:
     runs-on: ubuntu-latest
-    # container: rust:1.86-bullseye
+    container: rust:1.86-bullseye
     defaults:
       run:
         working-directory: ./backend
@@ -82,6 +85,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-workspaces: ./backend
 
       - name: Setup env
         run: cp -f .env.ci .env

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -18,6 +18,41 @@ env:
 
 jobs:
 
+  build:
+    runs-on: ubuntu-latest
+    container: rust:1.86-bullseye
+    services:
+      arcadiadb:
+        image: postgres
+        env:
+          POSTGRES_USER: arcadia
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    defaults:
+      run:
+        working-directory: ./backend
+    
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-workspaces: ./backend
+      
+      - name: Build
+        run: cargo build
+  
+      - name: Run tests
+        run: cargo test
+
   lint:
     runs-on: ubuntu-latest
 
@@ -33,14 +68,14 @@ jobs:
         with:
           components: clippy
           cache-workspaces: ./backend
-          cache-on-failure: true
   
       - name: Check clippy for new warnings
         run: cargo clippy
         env:
           SQLX_OFFLINE: "true"
   
-  build-schema-check:
+
+  schema-check:
     runs-on: ubuntu-latest
     container: rust:1.86-bullseye
     defaults:
@@ -68,20 +103,9 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: ./backend
-          cache-on-failure: true
 
       - name: Setup env
         run: cp -f .env.ci .env
-
-      - name: Build
-        run: cargo build
-        # env:
-        #  SQLX_OFFLINE: "true"
-  
-      - name: Run tests
-        run: cargo test
-        # env:
-        #  SQLX_OFFLINE: "true"
 
       - name: Install sqlx
         run: cargo install sqlx-cli

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -21,6 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container: rust:1.86-bullseye
+
     services:
       arcadiadb:
         image: postgres
@@ -46,6 +47,9 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: ./backend
+      
+      - name: Setup env
+        run: cp -f .env.ci .env
       
       - name: Build
         run: cargo build

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -35,9 +35,13 @@ jobs:
       
       - name: Build
         run: cargo build
+        env:
+          SQLX_OFFLINE: "true"
   
       - name: Run tests
         run: cargo test
+        env:
+          SQLX_OFFLINE: "true"
 
   lint:
     runs-on: ubuntu-latest
@@ -57,6 +61,8 @@ jobs:
   
       - name: Check clippy for new warnings
         run: cargo clippy
+        env:
+          SQLX_OFFLINE: "true"
   
 
   schema-check:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -20,6 +20,20 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    container: rust:1.86-bullseye
+    services:
+      arcadiadb:
+        image: postgres
+        env:
+          POSTGRES_USER: arcadia
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     defaults:
       run:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -2,8 +2,6 @@ name: Backend CI
 
 on:
   push:
-    branches:
-      - main
     paths:
       - 'backend/**'
       - '.github/workflows/backend.yml'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,8 +2,6 @@ name: Frontend CI
 
 on:
   push:
-    branches:
-      - main
     paths:
       - 'frontend/**'
       - '.github/workflows/frontend.yml'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,14 +4,18 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'frontend/**'
+      - '.github/workflows/frontend.yml'
 
 jobs:
-  check-lint-format:
+  lint:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -28,5 +32,7 @@ jobs:
 
     - run: npm ci
     - run: npm run lint
+      continue-on-error: true
     - run: npm run check-format
+      continue-on-error: true
     


### PR DESCRIPTION
Not only it fixes #66 it also now does schema checking, testing (+ building ofc) and linting in parallel as separate jobs with faster speed.
Also with separate jobs it's possible to make workflows (for example the docker one) wait for the build to complete successfully to not waste time building a docker image that won't work.