### PR TITLE
Fix publish and compose setup

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -21,3 +21,5 @@ jobs:
         with:
           image_name: ${{ github.repository }}  
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          dockerfile: ./backend/Dockerfile
+          context: ./backend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,6 +5,7 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloa
 WORKDIR /app
 # COPY . .
 COPY .sqlx/ ./sqlx/
+COPY vendored vendored
 
 COPY Cargo.toml Cargo.lock ./
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -13,6 +13,7 @@ use std::env;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
+
 use arcadia_index::{Arcadia, Error, OpenSignups, Result, api_doc::ApiDoc};
 
 #[actix_web::main]
@@ -31,6 +32,11 @@ async fn main() -> std::io::Result<()> {
         .connect(&database_url)
         .await
         .expect("Error building a connection pool");
+
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("Error running migrations");
 
     let host = env::var("ACTIX_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
     let port = env::var("ACTIX_PORT").unwrap_or_else(|_| "8080".to_string());

--- a/compose.yml
+++ b/compose.yml
@@ -13,7 +13,6 @@ services:
     #      size: 134217728 # 128*2^20 bytes = 128Mb
     volumes:
     - ./volumes/postgres-data/:/var/lib/postgresql/data/
-    - ./backend/migrations/:/docker-entrypoint-initdb.d/
     ports:
       - 5432:5432
     env_file:


### PR DESCRIPTION
Changes:
* Fixes the image publish setup, the publish action needed the context/dockerfile path adjusted with change over to a monorepo
* Fixes dockerfile - vendored deps were not getting pulled in at the right time
* Updates the docker-compose setup, the postgres container no longer runs migrations (it still does create the initial database, though)


The first two items would have been caught sooner if we ran a container build when new commits land in main. I think for now it's too wasteful, but something to keep in mind if we run into this issue again.

TODO:
* [ ] update contributing docs