### PR TITLE
frontend: fix ~120 type errors

### DIFF
--- a/frontend/src/components/AlbumOfTheMonth.vue
+++ b/frontend/src/components/AlbumOfTheMonth.vue
@@ -10,11 +10,12 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import Card from 'primevue/card'
 
-export default {
+export default defineComponent({
   components: { Card },
-}
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/BlogPosts.vue
+++ b/frontend/src/components/BlogPosts.vue
@@ -12,16 +12,17 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { ref } from 'vue'
 import Card from 'primevue/card'
 
-export default {
+export default defineComponent({
   components: { Card },
   setup() {
     const blogPosts = ref(['Server maintenance [Completed]'])
     return { blogPosts }
   },
-}
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/ContentContainer.vue
+++ b/frontend/src/components/ContentContainer.vue
@@ -6,10 +6,12 @@
 </template>
 
 <script lang="ts">
-export default {
+import { defineComponent } from 'vue'
+
+export default defineComponent({
   name: 'ContentContainer',
   props: { containerTitle: {}, slotClass: {} },
-}
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/CustomGalleria.vue
+++ b/frontend/src/components/CustomGalleria.vue
@@ -26,11 +26,12 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { Galleria } from 'primevue'
 
-export default {
+export default defineComponent({
   components: { Galleria },
-  props: { images: {} },
+  props: { images: [] },
   data() {
     return {
       modalVisible: false,
@@ -43,7 +44,7 @@ export default {
       this.modalVisible = true
     },
   },
-}
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/ExternalLink.vue
+++ b/frontend/src/components/ExternalLink.vue
@@ -3,9 +3,11 @@
 </template>
 
 <script lang="ts">
-export default {
+import { defineComponent } from 'vue'
+
+export default defineComponent({
   props: {
-    link: {},
+    link: { type: String, required: true },
   },
   methods: {
     getLinkLogo() {
@@ -35,7 +37,7 @@ export default {
       }
     },
   },
-}
+})
 </script>
 <style scoped>
 img {

--- a/frontend/src/components/LatestUploads.vue
+++ b/frontend/src/components/LatestUploads.vue
@@ -11,10 +11,11 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { ref } from 'vue'
 import Card from 'primevue/card'
 
-export default {
+export default defineComponent({
   components: { Card },
   setup() {
     const uploads = ref([
@@ -26,7 +27,7 @@ export default {
 
     return { uploads }
   },
-}
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/MasterGroupLink.vue
+++ b/frontend/src/components/MasterGroupLink.vue
@@ -8,12 +8,14 @@
 </template>
 
 <script lang="ts">
-export default {
+import { defineComponent } from 'vue'
+
+export default defineComponent({
   props: {
     title_group: {},
   },
   methods: {},
-}
+})
 </script>
 <style scoped>
 img {

--- a/frontend/src/components/MenuBar.vue
+++ b/frontend/src/components/MenuBar.vue
@@ -7,10 +7,11 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { ref } from 'vue'
 import { Button } from 'primevue'
 
-export default {
+export default defineComponent({
   components: { Button },
   setup() {
     const menuItems = ref([
@@ -31,7 +32,7 @@ export default {
       document.documentElement.classList.toggle('dark-theme')
     },
   },
-}
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/SearchBars.vue
+++ b/frontend/src/components/SearchBars.vue
@@ -35,9 +35,10 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import InputText from 'primevue/inputtext'
 
-export default {
+export default defineComponent({
   components: { InputText },
   data() {
     return {
@@ -52,7 +53,7 @@ export default {
     }
   },
   methods: {},
-}
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -29,10 +29,11 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { useUserStore } from '@/stores/user'
 import { Button } from 'primevue'
 
-export default {
+export default defineComponent({
   components: { Button },
   data() {
     return {
@@ -47,7 +48,7 @@ export default {
   created() {
     this.user = useUserStore()
   },
-}
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/artist/AffiliatedArtist.vue
+++ b/frontend/src/components/artist/AffiliatedArtist.vue
@@ -17,13 +17,15 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { Image } from 'primevue'
-export default {
+
+export default defineComponent({
   components: { Image },
   props: {
     affiliated_artist: {},
   },
-}
+})
 </script>
 <style scoped>
 .affiliated-artist {

--- a/frontend/src/components/artist/ArtistFullHeader.vue
+++ b/frontend/src/components/artist/ArtistFullHeader.vue
@@ -14,15 +14,17 @@
   </ContentContainer>
 </template>
 <script lang="ts">
+import { defineComponent } from 'vue'
 import ContentContainer from '@/components/ContentContainer.vue'
 import { Image } from 'primevue'
-export default {
+
+export default defineComponent({
   components: { ContentContainer, Image },
   props: { artist: {} },
   data() {
     return {}
   },
-}
+})
 </script>
 <style scoped>
 .header-wrapper {

--- a/frontend/src/components/artist/ArtistSidebar.vue
+++ b/frontend/src/components/artist/ArtistSidebar.vue
@@ -11,15 +11,17 @@
   </div>
 </template>
 <script lang="ts">
+import { defineComponent } from 'vue'
 import ContentContainer from '@/components/ContentContainer.vue'
 import { Image } from 'primevue'
-export default {
+
+export default defineComponent({
   components: { ContentContainer, Image },
   props: { artist: {} },
   data() {
     return {}
   },
-}
+})
 </script>
 <style scoped>
 .artist-sidebar {

--- a/frontend/src/components/artist/ArtistSlimHeader.vue
+++ b/frontend/src/components/artist/ArtistSlimHeader.vue
@@ -2,13 +2,15 @@
   <div class="name">{{ artist.name }}</div>
 </template>
 <script lang="ts">
-export default {
+import { defineComponent } from 'vue'
+
+export default defineComponent({
   components: {},
   props: { artist: {} },
   data() {
     return {}
   },
-}
+})
 </script>
 <style scoped>
 .name {

--- a/frontend/src/components/auth/LoginForm.vue
+++ b/frontend/src/components/auth/LoginForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <Form v-slot="$form" :initialValues="form" @submit="login">
+  <Form :initialValues="form" @submit="login">
     <div class="flex flex-col gap-1">
       <InputText
         class="form-item"
@@ -26,6 +26,7 @@
   </Form>
 </template>
 <script lang="ts">
+import { defineComponent } from 'vue'
 import InputText from 'primevue/inputtext'
 import Password from 'primevue/password'
 import { Form } from '@primevue/forms'
@@ -34,7 +35,7 @@ import Checkbox from 'primevue/checkbox'
 import { login } from '@/services/api/authService'
 import { useUserStore } from '@/stores/user'
 
-export default {
+export default defineComponent({
   components: { Button, InputText, Checkbox, Password, Form },
   data() {
     return {
@@ -56,5 +57,5 @@ export default {
       })
     },
   },
-}
+})
 </script>

--- a/frontend/src/components/auth/RegisterForm.vue
+++ b/frontend/src/components/auth/RegisterForm.vue
@@ -42,11 +42,12 @@
   />
 </template>
 <script lang="ts">
+import { defineComponent } from 'vue'
 import InputText from 'primevue/inputtext'
 import Button from 'primevue/button'
 import { register } from '@/services/api/authService'
 
-export default {
+export default defineComponent({
   components: { Button, InputText },
   data() {
     return {
@@ -65,5 +66,5 @@ export default {
       })
     },
   },
-}
+})
 </script>

--- a/frontend/src/components/community/BBCodeEditor.vue
+++ b/frontend/src/components/community/BBCodeEditor.vue
@@ -13,8 +13,10 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { FloatLabel, Textarea } from 'primevue'
-export default {
+
+export default defineComponent({
   components: { FloatLabel, Textarea },
   props: { label: {} },
   data() {
@@ -22,5 +24,5 @@ export default {
       content: '',
     }
   },
-}
+})
 </script>

--- a/frontend/src/components/community/GeneralComment.vue
+++ b/frontend/src/components/community/GeneralComment.vue
@@ -22,13 +22,15 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import ContentContainer from '@/components/ContentContainer.vue'
-export default {
+
+export default defineComponent({
   components: { ContentContainer },
   props: {
     comment: {},
   },
-}
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/community/GeneralComments.vue
+++ b/frontend/src/components/community/GeneralComments.vue
@@ -27,6 +27,7 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import GeneralComment from './GeneralComment.vue'
 import { Button } from 'primevue'
 import { postTitleGroupComment } from '@/services/api/commentService'
@@ -35,7 +36,7 @@ import { Form } from '@primevue/forms'
 import Message from 'primevue/message'
 import { useUserStore } from '@/stores/user'
 
-export default {
+export default defineComponent({
   components: { GeneralComment, BBCodeEditor, Button, Form, Message },
   props: {
     comments: [],
@@ -85,7 +86,7 @@ export default {
       })
     },
   },
-}
+})
 </script>
 <style scoped>
 .new-comment {

--- a/frontend/src/components/edition_group/CreateOrEditEditionGroup.vue
+++ b/frontend/src/components/edition_group/CreateOrEditEditionGroup.vue
@@ -164,6 +164,7 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import FloatLabel from 'primevue/floatlabel'
 import InputText from 'primevue/inputtext'
 import Textarea from 'primevue/textarea'
@@ -173,7 +174,7 @@ import DatePicker from 'primevue/datepicker'
 import Message from 'primevue/message'
 import { Form } from '@primevue/forms'
 
-export default {
+export default defineComponent({
   components: {
     Form,
     DatePicker,
@@ -274,7 +275,7 @@ export default {
       this.editionGroupForm.additional_information.catalogue_number = ''
     }
   },
-}
+})
 </script>
 <style scoped>
 .description {

--- a/frontend/src/components/edition_group/CreateOrSelectEditionGroup.vue
+++ b/frontend/src/components/edition_group/CreateOrSelectEditionGroup.vue
@@ -48,6 +48,7 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import FloatLabel from 'primevue/floatlabel'
 import Select from 'primevue/select'
 import Button from 'primevue/button'
@@ -55,7 +56,7 @@ import { createEditionGroup } from '@/services/api/torrentService'
 import { useTitleGroupStore } from '@/stores/titleGroup'
 import CreateOrEditEditionGroup from './CreateOrEditEditionGroup.vue'
 
-export default {
+export default defineComponent({
   components: {
     Button,
     FloatLabel,
@@ -95,7 +96,7 @@ export default {
       this.titleGroup = titleGroupStore
     }
   },
-}
+})
 </script>
 <style scoped>
 .title {

--- a/frontend/src/components/request/TorrentRequestsTable.vue
+++ b/frontend/src/components/request/TorrentRequestsTable.vue
@@ -20,12 +20,13 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { Column, DataTable } from 'primevue'
-export default {
+export default defineComponent({
   components: { DataTable, Column },
   props: {
     torrent_requests: {},
   },
-}
+})
 </script>
 <style scoped></style>

--- a/frontend/src/components/series/SeriesFullHeader.vue
+++ b/frontend/src/components/series/SeriesFullHeader.vue
@@ -15,12 +15,14 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import ContentContainer from '@/components/ContentContainer.vue'
 import { Image } from 'primevue'
-export default {
+
+export default defineComponent({
   components: { ContentContainer, Image },
   props: { series: {} },
-}
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/series/SeriesSidebar.vue
+++ b/frontend/src/components/series/SeriesSidebar.vue
@@ -12,12 +12,14 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import ContentContainer from '@/components/ContentContainer.vue'
 import { Image } from 'primevue'
-export default {
+
+export default defineComponent({
   components: { ContentContainer, Image },
   props: { series: {} },
-}
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/series/SeriesSlimHeader.vue
+++ b/frontend/src/components/series/SeriesSlimHeader.vue
@@ -3,9 +3,11 @@
 </template>
 
 <script lang="ts">
-export default {
+import { defineComponent } from 'vue'
+
+export default defineComponent({
   props: { series: {} },
-}
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/title_group/CreateOrEditTitleGroup.vue
+++ b/frontend/src/components/title_group/CreateOrEditTitleGroup.vue
@@ -233,6 +233,7 @@
   </Form>
 </template>
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { Form } from '@primevue/forms'
 import FloatLabel from 'primevue/floatlabel'
 import InputText from 'primevue/inputtext'
@@ -243,7 +244,7 @@ import DatePicker from 'primevue/datepicker'
 import Message from 'primevue/message'
 import { InputNumber } from 'primevue'
 
-export default {
+export default defineComponent({
   components: {
     Form,
     DatePicker,
@@ -378,7 +379,7 @@ export default {
       this.titleGroupForm = this.initialTitleGroupForm
     }
   },
-}
+})
 </script>
 <style scoped>
 .description {

--- a/frontend/src/components/title_group/CreateOrSelectTitleGroup.vue
+++ b/frontend/src/components/title_group/CreateOrSelectTitleGroup.vue
@@ -155,6 +155,7 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { InputNumber } from 'primevue'
 import FloatLabel from 'primevue/floatlabel'
 import InputText from 'primevue/inputtext'
@@ -167,7 +168,7 @@ import { createTitleGroup, getTitleGroupLite } from '@/services/api/torrentServi
 import { useTitleGroupStore } from '@/stores/titleGroup'
 import CreateOrEditTitleGroup from '../title_group/CreateOrEditTitleGroup.vue'
 
-export default {
+export default defineComponent({
   components: {
     CreateOrEditTitleGroup,
     Button,
@@ -253,7 +254,7 @@ export default {
       this.titleGroupId = this.titleGroupStore.id.toString()
     }
   },
-}
+})
 </script>
 <style scoped>
 .title {

--- a/frontend/src/components/title_group/TitleGroupFullHeader.vue
+++ b/frontend/src/components/title_group/TitleGroupFullHeader.vue
@@ -71,6 +71,7 @@
   </ContentContainer>
 </template>
 <script lang="ts">
+import { defineComponent } from 'vue'
 import ContentContainer from '@/components/ContentContainer.vue'
 
 import { Galleria } from 'primevue'
@@ -78,7 +79,7 @@ import Image from 'primevue/image'
 import AffiliatedArtist from '@/components/artist/AffiliatedArtist.vue'
 import ExternalLink from '@/components/ExternalLink.vue'
 
-export default {
+export default defineComponent({
   components: {
     ContentContainer,
     Galleria,
@@ -89,7 +90,7 @@ export default {
   props: {
     title_group: {},
   },
-}
+})
 </script>
 <style scoped>
 #title-group-header {

--- a/frontend/src/components/title_group/TitleGroupPreviewCoverOnly.vue
+++ b/frontend/src/components/title_group/TitleGroupPreviewCoverOnly.vue
@@ -11,14 +11,16 @@
   </div>
 </template>
 <script lang="ts">
-export default {
+import { defineComponent } from 'vue'
+
+export default defineComponent({
   props: {
     title_group: {},
   },
   methods: {
     titleGroupClicked() {},
   },
-}
+})
 </script>
 
 <style>

--- a/frontend/src/components/title_group/TitleGroupPreviewTable.vue
+++ b/frontend/src/components/title_group/TitleGroupPreviewTable.vue
@@ -25,10 +25,12 @@
   </ContentContainer>
 </template>
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { Image } from 'primevue'
 import TitleGroupTable from './TitleGroupTable.vue'
 import ContentContainer from '../ContentContainer.vue'
-export default {
+
+export default defineComponent({
   components: { Image, TitleGroupTable, ContentContainer },
   props: {
     title_group: {},
@@ -36,7 +38,7 @@ export default {
   methods: {
     titleGroupClicked() {},
   },
-}
+})
 </script>
 <style scoped>
 .title-group-preview-table {

--- a/frontend/src/components/title_group/TitleGroupSidebar.vue
+++ b/frontend/src/components/title_group/TitleGroupSidebar.vue
@@ -57,6 +57,7 @@
   </div>
 </template>
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { Galleria } from 'primevue'
 import Image from 'primevue/image'
 import AffiliatedArtist from '@/components/artist/AffiliatedArtist.vue'
@@ -64,7 +65,7 @@ import ExternalLink from '@/components/ExternalLink.vue'
 import MasterGroupLink from '@/components/MasterGroupLink.vue'
 import ContentContainer from '../ContentContainer.vue'
 
-export default {
+export default defineComponent({
   components: {
     Galleria,
     Image,
@@ -76,7 +77,7 @@ export default {
   props: {
     title_group: {},
   },
-}
+})
 </script>
 <style scoped>
 #title-group-sidebar {

--- a/frontend/src/components/title_group/TitleGroupSlimHeader.vue
+++ b/frontend/src/components/title_group/TitleGroupSlimHeader.vue
@@ -17,12 +17,14 @@
   </div>
 </template>
 <script lang="ts">
-export default {
+import { defineComponent } from 'vue'
+
+export default defineComponent({
   components: {},
   props: {
     title_group: {},
   },
-}
+})
 </script>
 <style scoped>
 .title {

--- a/frontend/src/components/title_group/TitleGroupTable.vue
+++ b/frontend/src/components/title_group/TitleGroupTable.vue
@@ -164,6 +164,7 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import DataTable from 'primevue/datatable'
 import Column from 'primevue/column'
 import DOMPurify from 'dompurify'
@@ -175,7 +176,7 @@ import ReportTorrentDialog from '../torrent/ReportTorrentDialog.vue'
 import Dialog from 'primevue/dialog'
 import { downloadTorrent } from '@/services/api/torrentService'
 
-export default {
+export default defineComponent({
   components: {
     DataTable,
     Column,
@@ -245,7 +246,7 @@ export default {
       }
     },
   },
-}
+})
 </script>
 <style scoped>
 .feature {

--- a/frontend/src/components/torrent/CreateOrEditTorrent.vue
+++ b/frontend/src/components/torrent/CreateOrEditTorrent.vue
@@ -279,6 +279,7 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import FloatLabel from 'primevue/floatlabel'
 import InputText from 'primevue/inputtext'
 import Textarea from 'primevue/textarea'
@@ -295,7 +296,7 @@ import { useEditionGroupStore } from '@/stores/editionGroup'
 import { uploadTorrent } from '@/services/api/torrentService'
 import { useTitleGroupStore } from '@/stores/titleGroup'
 
-export default {
+export default defineComponent({
   components: {
     Form,
     Message,
@@ -458,7 +459,7 @@ export default {
     this.torrentForm.edition_group_id = editionGroupStore.id
     console.log(this.content_type)
   },
-}
+})
 </script>
 <style scoped>
 #create-torrent {

--- a/frontend/src/components/torrent/ReportTorrentDialog.vue
+++ b/frontend/src/components/torrent/ReportTorrentDialog.vue
@@ -9,11 +9,12 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import { reportTorrent } from '@/services/api/torrentService'
 import { Textarea, FloatLabel } from 'primevue'
 import Button from 'primevue/button'
 
-export default {
+export default defineComponent({
   components: { Textarea, FloatLabel, Button },
   props: { torrentId: {} },
   data() {
@@ -32,7 +33,7 @@ export default {
       })
     },
   },
-}
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/torrent/TorrentSearchInputs.vue
+++ b/frontend/src/components/torrent/TorrentSearchInputs.vue
@@ -22,11 +22,13 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
 import ContentContainer from '../ContentContainer.vue'
 import InputText from 'primevue/inputtext'
 import FloatLabel from 'primevue/floatlabel'
 import Button from 'primevue/button'
-export default {
+
+export default defineComponent({
   components: { ContentContainer, Button, InputText, FloatLabel },
   props: { loading: { default: false }, initialTitleGroupName: {} },
   data() {
@@ -39,7 +41,7 @@ export default {
   created() {
     this.searchForm.title_group_name = this.initialTitleGroupName
   },
-}
+})
 </script>
 
 <style>

--- a/frontend/src/vue-global-properties.d.ts
+++ b/frontend/src/vue-global-properties.d.ts
@@ -1,6 +1,6 @@
 import type { ComponentCustomProperties } from 'vue'
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $timeAgo: (date: string) => string
     $bytesToReadable: (bytes: number) => string


### PR DESCRIPTION
Allow for vue to do some clever `prop` type inference using `defineComponent` as described here:

https://vuejs.org/guide/typescript/overview#general-usage-notes

Extend `ComponentCustomProperties` as described here:

https://vuejs.org/api/utility-types#componentcustomproperties

(Instead of extending `@vue/runtime-core`, extend `vue`, this allows for the custom extensions from `vue-i18n` and `vue-router` to also enable their extended types)