### PR TITLE
defining nested structs

### DIFF
--- a/backend/src/api_doc.rs
+++ b/backend/src/api_doc.rs
@@ -10,7 +10,7 @@ use crate::{
         edition_group::EditionGroup,
         invitation::{Invitation, SentInvitation},
         master_group::{MasterGroup, UserCreatedMasterGroup},
-        series::{Series, UserCreatedSeries},
+        series::{Series, SeriesAndTitleGroupHierarchyLite, UserCreatedSeries},
         title_group_comment::{TitleGroupComment, UserCreatedTitleGroupComment},
         torrent::TorrentSearch,
         torrent_report::{TorrentReport, UserCreatedTorrentReport},
@@ -75,7 +75,8 @@ use crate::{
         UserCreatedTorrentRequestVote,
         UserCreatedTorrentReport,
         TorrentReport,
-        ArtistLite
+        ArtistLite,
+        SeriesAndTitleGroupHierarchyLite
     ),)
 )]
 pub struct ApiDoc;

--- a/backend/src/api_doc.rs
+++ b/backend/src/api_doc.rs
@@ -6,13 +6,14 @@ use crate::{
         torrent_handler::DownloadTorrentQuery,
     },
     models::{
-        artist::{AffiliatedArtist, Artist, ArtistLite},
+        artist::{AffiliatedArtist, Artist, ArtistAndTitleGroupsLite, ArtistLite},
         edition_group::EditionGroup,
         invitation::{Invitation, SentInvitation},
         master_group::{MasterGroup, UserCreatedMasterGroup},
         series::{Series, SeriesAndTitleGroupHierarchyLite, UserCreatedSeries},
+        title_group::{TitleGroupHierarchy, TitleGroupInfoLite},
         title_group_comment::{TitleGroupComment, UserCreatedTitleGroupComment},
-        torrent::TorrentSearch,
+        torrent::{TorrentSearch, TorrentSearchResults},
         torrent_report::{TorrentReport, UserCreatedTorrentReport},
         torrent_request::{TorrentRequest, UserCreatedTorrentRequest},
         torrent_request_vote::{TorrentRequestVote, UserCreatedTorrentRequestVote},
@@ -76,7 +77,11 @@ use crate::{
         UserCreatedTorrentReport,
         TorrentReport,
         ArtistLite,
-        SeriesAndTitleGroupHierarchyLite
+        SeriesAndTitleGroupHierarchyLite,
+        ArtistAndTitleGroupsLite,
+        TitleGroupHierarchy,
+        TitleGroupInfoLite,
+        TorrentSearchResults
     ),)
 )]
 pub struct ApiDoc;

--- a/backend/src/handlers/artist_handler.rs
+++ b/backend/src/handlers/artist_handler.rs
@@ -2,7 +2,8 @@ use crate::{
     Arcadia, Result,
     handlers::UserId,
     models::artist::{
-        AffiliatedArtist, Artist, ArtistLite, UserCreatedAffiliatedArtist, UserCreatedArtist,
+        AffiliatedArtist, Artist, ArtistAndTitleGroupsLite, ArtistLite,
+        UserCreatedAffiliatedArtist, UserCreatedArtist,
     },
     repositories::artist_repository::{
         create_artist, create_artists_affiliation, find_artist_publications, find_artists_lite,
@@ -56,7 +57,7 @@ pub struct GetArtistPublicationsQuery {
     path = "/api/artist",
     params (GetArtistPublicationsQuery),
     responses(
-        (status = 200, description = "Successfully got the artist's pulications"),
+        (status = 200, description = "Successfully got the artist's pulications", body=ArtistAndTitleGroupsLite),
     )
 )]
 pub async fn get_artist_publications(

--- a/backend/src/handlers/series_handler.rs
+++ b/backend/src/handlers/series_handler.rs
@@ -1,7 +1,7 @@
 use crate::{
     Arcadia, Result,
     models::{
-        series::{Series, UserCreatedSeries},
+        series::{Series, SeriesAndTitleGroupHierarchyLite, UserCreatedSeries},
         user::User,
     },
     repositories::series_repository::{create_series, find_series},
@@ -37,7 +37,7 @@ pub struct GetSeriesQuery {
     path = "/api/series",
     params (GetSeriesQuery),
     responses(
-        (status = 200, description = "Successfully got the series"),
+        (status = 200, description = "Successfully got the series", body=SeriesAndTitleGroupHierarchyLite),
     )
 )]
 pub async fn get_series(

--- a/backend/src/handlers/title_group_handler.rs
+++ b/backend/src/handlers/title_group_handler.rs
@@ -5,11 +5,11 @@ use utoipa::IntoParams;
 use crate::{
     Arcadia, Result,
     models::{
-        title_group::{TitleGroup, UserCreatedTitleGroup},
+        title_group::{TitleGroup, TitleGroupHierarchy, TitleGroupInfoLite, UserCreatedTitleGroup},
         user::User,
     },
     repositories::title_group_repository::{
-        create_title_group, find_lite_title_group_info, find_title_group,
+        create_title_group, find_title_group, find_title_group_info_lite,
     },
 };
 
@@ -40,7 +40,7 @@ pub struct GetTitleGroupQuery {
     path = "/api/title-group",
     params(GetTitleGroupQuery),
     responses(
-        (status = 200, description = "Successfully got the title_group"),
+        (status = 200, description = "Successfully got the title_group", body=TitleGroupHierarchy),
     )
 )]
 pub async fn get_title_group(
@@ -60,14 +60,14 @@ pub type GetTitleGroupInfoLiteQuery = GetTitleGroupQuery;
     path = "/api/title-group/lite",
     params(GetTitleGroupInfoLiteQuery),
     responses(
-        (status = 200, description = "Successfully got the title_group (lite info)"),
+        (status = 200, description = "Successfully got the title_group (lite info)", body=TitleGroupInfoLite),
     )
 )]
 pub async fn get_title_group_info_lite(
     arc: web::Data<Arcadia>,
     query: web::Query<GetTitleGroupInfoLiteQuery>,
 ) -> Result<HttpResponse> {
-    let title_group = find_lite_title_group_info(&arc.pool, query.id).await?;
+    let title_group = find_title_group_info_lite(&arc.pool, query.id).await?;
 
     Ok(HttpResponse::Ok().json(title_group))
 }

--- a/backend/src/handlers/torrent_handler.rs
+++ b/backend/src/handlers/torrent_handler.rs
@@ -12,7 +12,7 @@ use utoipa::{IntoParams, ToSchema};
 use crate::{
     Arcadia, Result,
     models::{
-        torrent::{TorrentSearch, UploadedTorrent},
+        torrent::{TorrentSearch, TorrentSearchResults, UploadedTorrent},
         user::User,
     },
     repositories::torrent_repository::{create_torrent, get_torrent, search_torrents},
@@ -81,7 +81,7 @@ pub async fn download_dottorrent_file(
     get,
     path = "/api/search/torrent",
     responses(
-        (status = 200, description = "Title groups and their torrents found"),
+        (status = 200, description = "Title groups and their torrents found", body=TorrentSearchResults),
     )
 )]
 pub async fn find_torrents(

--- a/backend/src/models/artist.rs
+++ b/backend/src/models/artist.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use sqlx::prelude::FromRow;
 use utoipa::ToSchema;
 
+use super::title_group::TitleGroupHierarchyLite;
+
 #[derive(Debug, Deserialize, Serialize, FromRow, ToSchema)]
 pub struct Artist {
     pub id: i64,
@@ -102,4 +104,22 @@ pub struct UserCreatedAffiliatedArtist {
     pub artist_id: i64,
     pub roles: Vec<ArtistRole>,
     pub nickname: Option<String>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ArtistAndTitleGroupsLite {
+    pub artist: Artist,
+    pub title_groups: Vec<TitleGroupHierarchyLite>,
+}
+
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct AffiliatedArtistHierarchy {
+    pub title_group_id: i64,
+    pub artist_id: i64,
+    pub roles: Vec<ArtistRole>,
+    pub nickname: Option<String>,
+    #[schema(value_type = String, format = DateTime)]
+    pub created_at: NaiveDateTime,
+    pub created_by_id: i64,
+    pub artist: Artist,
 }

--- a/backend/src/models/artist.rs
+++ b/backend/src/models/artist.rs
@@ -108,7 +108,10 @@ pub struct UserCreatedAffiliatedArtist {
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ArtistAndTitleGroupsLite {
+    // used for the API doc, but not sure why it's considered dead code
+    #[allow(dead_code)]
     pub artist: Artist,
+    #[allow(dead_code)]
     pub title_groups: Vec<TitleGroupHierarchyLite>,
 }
 

--- a/backend/src/models/edition_group.rs
+++ b/backend/src/models/edition_group.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use sqlx::{prelude::FromRow, types::Json};
 use utoipa::ToSchema;
 
-use super::torrent::TorrentLite;
+use super::torrent::{TorrentHierarchy, TorrentLite};
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, sqlx::Type)]
 #[sqlx(type_name = "source_enum")]
@@ -99,7 +99,7 @@ pub struct UserCreatedEditionGroup {
 }
 
 #[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
-pub struct EditionGroupHierachyLite {
+pub struct EditionGroupHierarchyLite {
     pub id: i64,
     pub title_group_id: i64,
     pub name: String,
@@ -111,4 +111,38 @@ pub struct EditionGroupHierachyLite {
     #[schema(value_type = Value)]
     pub additional_information: Option<Json<Value>>,
     pub torrents: Vec<TorrentLite>,
+}
+
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct EditionGroupHierarchy {
+    pub id: i64,
+    pub title_group_id: i64,
+    pub name: String,
+    #[schema(value_type = String, format = DateTime)]
+    pub release_date: NaiveDateTime,
+    #[schema(value_type = String, format = DateTime)]
+    pub created_at: NaiveDateTime,
+    #[schema(value_type = String, format = DateTime)]
+    pub updated_at: NaiveDateTime,
+    pub created_by_id: i64,
+    pub description: Option<String>,
+    pub distributor: Option<String>,
+    pub covers: Vec<String>,
+    pub external_links: Vec<String>,
+    pub source: Option<Source>,
+    #[schema(value_type = Value)]
+    pub additional_information: Option<Json<Value>>,
+    pub torrents: Vec<TorrentHierarchy>,
+}
+
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct EditionGroupInfoLite {
+    pub id: i64,
+    pub name: String,
+    #[schema(value_type = String, format = DateTime)]
+    pub release_date: NaiveDateTime,
+    pub distributor: Option<String>,
+    pub source: Option<Source>,
+    #[schema(value_type = Value)]
+    pub additional_information: Option<Json<Value>>,
 }

--- a/backend/src/models/edition_group.rs
+++ b/backend/src/models/edition_group.rs
@@ -98,15 +98,17 @@ pub struct UserCreatedEditionGroup {
     // pub title_group: Option<UserCreatedTitleGroup>,
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct EditionGroupHierachyLite {
     pub id: i64,
     pub title_group_id: i64,
     pub name: String,
+    #[schema(value_type = String, format = DateTime)]
     pub release_date: NaiveDateTime,
     pub distributor: Option<String>,
     pub covers: Vec<String>,
     pub source: Option<Source>,
+    #[schema(value_type = Value)]
     pub additional_information: Option<Json<Value>>,
     pub torrents: Vec<TorrentLite>,
 }

--- a/backend/src/models/series.rs
+++ b/backend/src/models/series.rs
@@ -34,3 +34,9 @@ pub struct SeriesAndTitleGroupHierarchyLite {
     pub series: Series,
     pub title_groups: Vec<TitleGroupHierarchyLite>,
 }
+
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+pub struct SeriesLite {
+    pub id: i64,
+    pub name: String,
+}

--- a/backend/src/models/series.rs
+++ b/backend/src/models/series.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use sqlx::prelude::FromRow;
 use utoipa::ToSchema;
 
+use super::title_group::TitleGroupHierarchyLite;
+
 #[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct Series {
     pub id: i64,
@@ -25,4 +27,10 @@ pub struct UserCreatedSeries {
     pub covers: Vec<String>,
     pub banners: Vec<String>,
     pub tags: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+pub struct SeriesAndTitleGroupHierarchyLite {
+    pub series: Series,
+    pub title_groups: Vec<TitleGroupHierarchyLite>,
 }

--- a/backend/src/models/title_group.rs
+++ b/backend/src/models/title_group.rs
@@ -142,16 +142,18 @@ pub struct UserCreatedTitleGroup {
     // pub master_group: Option<UserCreatedMasterGroup>,
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct TitleGroupHierarchyLite {
     pub name: String,
     pub covers: Option<Vec<String>>,
     pub category: Option<TitleGroupCategory>,
     pub content_type: ContentType,
     pub tags: Vec<String>,
+    #[schema(value_type = String, format = DateTime)]
     pub original_release_date: NaiveDateTime,
-    pub affiliated_artists: Vec<Json<Value>>,
-    pub editions: Vec<EditionGroupHierachyLite>,
+    // #[schema(value_type = Value)]
+    // pub affiliated_artists: Vec<Json<Value>>,
+    pub edition_groups: Vec<EditionGroupHierachyLite>,
 }
 
 pub fn create_default_title_group() -> UserCreatedTitleGroup {

--- a/backend/src/models/title_group.rs
+++ b/backend/src/models/title_group.rs
@@ -4,7 +4,12 @@ use serde_json::{Value, json};
 use sqlx::{prelude::FromRow, types::Json};
 use utoipa::ToSchema;
 
-use super::edition_group::EditionGroupHierachyLite;
+use super::{
+    artist::AffiliatedArtistHierarchy,
+    edition_group::{EditionGroupHierarchy, EditionGroupHierarchyLite, EditionGroupInfoLite},
+    series::SeriesLite,
+    torrent_request::TorrentRequest,
+};
 
 #[derive(Debug, Serialize, Deserialize, sqlx::Type, ToSchema)]
 #[sqlx(type_name = "content_type_enum")]
@@ -153,7 +158,65 @@ pub struct TitleGroupHierarchyLite {
     pub original_release_date: NaiveDateTime,
     // #[schema(value_type = Value)]
     // pub affiliated_artists: Vec<Json<Value>>,
-    pub edition_groups: Vec<EditionGroupHierachyLite>,
+    pub edition_groups: Vec<EditionGroupHierarchyLite>,
+}
+
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct TitleGroupLite {
+    pub id: i64,
+    pub name: String,
+    pub content_type: ContentType,
+    pub edition_groups: Vec<EditionGroupInfoLite>,
+}
+
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct TitleGroupInfoLite {
+    pub id: i64,
+    pub name: String,
+    pub content_type: ContentType,
+}
+
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct TitleGroupHierarchy {
+    pub id: i64,
+    pub master_group_id: Option<i64>,
+    pub name: String,
+    pub name_aliases: Vec<String>,
+    #[schema(value_type = String, format = DateTime)]
+    pub created_at: NaiveDateTime,
+    #[schema(value_type = String, format = DateTime)]
+    pub updated_at: NaiveDateTime,
+    pub created_by_id: i64,
+    pub description: String,
+    pub platform: Option<Platform>,
+    pub original_language: Option<String>,
+    #[schema(value_type = String, format = DateTime)]
+    pub original_release_date: NaiveDateTime,
+    pub tagline: Option<String>,
+    pub country_from: Option<String>,
+    pub covers: Option<Vec<String>>,
+    pub external_links: Vec<String>,
+    #[schema(value_type = Value)]
+    pub embedded_links: Option<Json<Value>>,
+    pub category: Option<TitleGroupCategory>,
+    pub content_type: ContentType,
+    pub tags: Vec<String>,
+    #[schema(value_type = Value)]
+    pub public_ratings: Option<Json<Value>>,
+    pub series_id: Option<i64>,
+    pub screenshots: Vec<String>,
+    pub edition_groups: Vec<EditionGroupHierarchy>,
+}
+
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct TitleGroupAndAssociatedData {
+    pub title_group: TitleGroupHierarchy,
+    pub series: SeriesLite,
+    pub affiliated_artists: AffiliatedArtistHierarchy,
+    pub title_group_comments: Vec<TitleGroupHierarchy>,
+    pub torrent_requests: Vec<TorrentRequest>,
+    pub is_subscribed: bool,
+    pub in_same_master_group: Vec<TitleGroupLite>,
 }
 
 pub fn create_default_title_group() -> UserCreatedTitleGroup {

--- a/backend/src/models/title_group_comment.rs
+++ b/backend/src/models/title_group_comment.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use sqlx::prelude::FromRow;
 use utoipa::ToSchema;
 
+use super::user::UserLiteAvatar;
+
 #[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct TitleGroupComment {
     pub id: i64,
@@ -23,4 +25,19 @@ pub struct UserCreatedTitleGroupComment {
     pub title_group_id: i64,
     pub refers_to_torrent_id: Option<i64>,
     pub answers_to_comment_id: Option<i64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct TitleGroupCommentHierarchy {
+    pub id: i64,
+    pub content: String,
+    #[schema(value_type = String, format = DateTime)]
+    pub created_at: NaiveDateTime,
+    #[schema(value_type = String, format = DateTime)]
+    pub updated_at: NaiveDateTime,
+    pub created_by_id: i64,
+    pub title_group_id: i64,
+    pub refers_to_torrent_id: Option<i64>,
+    pub answers_to_comment_id: Option<i64>,
+    pub created_by: UserLiteAvatar,
 }

--- a/backend/src/models/torrent.rs
+++ b/backend/src/models/torrent.rs
@@ -9,19 +9,36 @@ use utoipa::ToSchema;
 
 #[derive(Debug, Deserialize, Serialize, sqlx::Type, ToSchema)]
 #[sqlx(type_name = "audio_codec_enum")]
-#[sqlx(rename_all = "lowercase")]
 pub enum AudioCodec {
+    #[sqlx(rename = "mp2")]
+    #[serde(alias = "mp2")]
     Mp2,
+    #[sqlx(rename = "mp3")]
+    #[serde(alias = "mp3")]
     Mp3,
+    #[sqlx(rename = "aac")]
+    #[serde(alias = "aac")]
     Aac,
+    #[sqlx(rename = "ac3")]
+    #[serde(alias = "ac3")]
     Ac3,
+    #[sqlx(rename = "dts")]
+    #[serde(alias = "dts")]
     Dts,
+    #[sqlx(rename = "flac")]
+    #[serde(alias = "flac")]
     Flac,
+    #[sqlx(rename = "pcm")]
+    #[serde(alias = "pcm")]
     Pcm,
     #[sqlx(rename = "true-hd")]
     #[serde(alias = "true-hd")]
     TrueHd,
+    #[sqlx(rename = "opus")]
+    #[serde(alias = "opus")]
     Opus,
+    #[sqlx(rename = "dsd")]
+    #[serde(alias = "dsd")]
     Dsd,
 }
 
@@ -256,12 +273,14 @@ pub struct TorrentSearch {
     pub title_group_name: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct TorrentLite {
     pub id: i64,
     pub edition_group_id: i64,
+    #[schema(value_type = String, format = DateTime)]
     pub created_at: NaiveDateTime,
     pub release_name: Option<String>,
+    #[schema(value_type = Value)]
     pub file_amount_per_type: Json<Value>,
     pub trumpable: Option<String>,
     pub staff_checked: bool,

--- a/backend/src/models/torrent.rs
+++ b/backend/src/models/torrent.rs
@@ -7,6 +7,8 @@ use serde_json::Value;
 use sqlx::{prelude::FromRow, types::Json};
 use utoipa::ToSchema;
 
+use super::{title_group::TitleGroupHierarchyLite, user::UserLite};
+
 #[derive(Debug, Deserialize, Serialize, sqlx::Type, ToSchema)]
 #[sqlx(type_name = "audio_codec_enum")]
 pub enum AudioCodec {
@@ -296,4 +298,44 @@ pub struct TorrentLite {
     pub features: Option<Vec<Features>>,
     pub subtitle_languages: Option<Vec<Language>>,
     pub video_resolution: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct TorrentHierarchy {
+    pub id: i64,
+    pub edition_group_id: i64,
+    #[schema(value_type = String, format = DateTime)]
+    pub created_at: NaiveDateTime,
+    #[schema(value_type = String, format = DateTime)]
+    pub updated_at: NaiveDateTime,
+    pub created_by_id: i64,
+    pub release_name: Option<String>,
+    pub release_group: Option<String>,
+    pub description: Option<String>,
+    #[schema(value_type = Value)]
+    pub file_amount_per_type: Json<Value>,
+    pub uploaded_as_anonymous: bool,
+    #[schema(value_type = Value)]
+    pub file_list: Json<Value>,
+    pub mediainfo: String,
+    pub trumpable: Option<String>,
+    pub staff_checked: bool,
+    pub languages: Option<Vec<Language>>,
+    pub container: String,
+    pub size: i64,
+    pub duration: Option<i32>,
+    pub audio_codec: Option<AudioCodec>,
+    pub audio_bitrate: Option<i32>,
+    pub audio_bitrate_sampling: Option<AudioBitrateSampling>,
+    pub audio_channels: Option<AudioChannels>,
+    pub video_codec: Option<VideoCodec>,
+    pub features: Option<Vec<Features>>,
+    pub subtitle_languages: Option<Vec<Language>>,
+    pub video_resolution: Option<String>,
+    pub uploader: UserLite,
+}
+
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct TorrentSearchResults {
+    pub title_groups: Vec<TitleGroupHierarchyLite>,
 }

--- a/backend/src/models/user.rs
+++ b/backend/src/models/user.rs
@@ -126,3 +126,16 @@ pub struct PublicUser {
     pub invitations: i16,
     pub bonus_points: i64,
 }
+
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct UserLite {
+    pub id: i64,
+    pub username: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct UserLiteAvatar {
+    pub id: i64,
+    pub username: String,
+    pub avatar: Option<String>,
+}

--- a/backend/src/repositories/series_repository.rs
+++ b/backend/src/repositories/series_repository.rs
@@ -75,5 +75,6 @@ pub async fn find_series(pool: &PgPool, series_id: &i64) -> Result<Value> {
     .await
     .map_err(|_| Error::SeriesWithIdNotFound(*series_id))?;
 
+    // Ok(serde_json::from_value(found_series.series_and_groups.unwrap()).unwrap())
     Ok(found_series.series_and_groups.unwrap())
 }

--- a/backend/src/repositories/title_group_repository.rs
+++ b/backend/src/repositories/title_group_repository.rs
@@ -151,7 +151,7 @@ pub async fn find_title_group(
 
     Ok(title_group.title_group_data.unwrap())
 }
-pub async fn find_lite_title_group_info(pool: &PgPool, title_group_id: i64) -> Result<Value> {
+pub async fn find_title_group_info_lite(pool: &PgPool, title_group_id: i64) -> Result<Value> {
     let title_group = sqlx::query!(
         r#"SELECT jsonb_build_object(
     'id', tg.id, 'content_type', tg.content_type, 'name', tg.name,

--- a/backend/src/repositories/torrent_repository.rs
+++ b/backend/src/repositories/torrent_repository.rs
@@ -1,16 +1,14 @@
 use crate::{
     Error, Result,
     models::{
-        title_group::TitleGroupHierarchyLite,
         torrent::{Features, Torrent, TorrentSearch, UploadedTorrent},
         user::User,
     },
 };
 
 use bip_metainfo::{Info, Metainfo, MetainfoBuilder, PieceLength};
-use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use sqlx::{PgPool, prelude::FromRow};
+use sqlx::PgPool;
 use std::str::FromStr;
 
 use super::notification_repository::notify_users;

--- a/backend/src/repositories/torrent_repository.rs
+++ b/backend/src/repositories/torrent_repository.rs
@@ -209,11 +209,6 @@ pub async fn get_torrent(
     })
 }
 
-#[derive(Debug, Serialize, Deserialize, FromRow)]
-pub struct TorrentSearchResults {
-    pub title_groups: Vec<TitleGroupHierarchyLite>,
-}
-
 pub async fn search_torrents(pool: &PgPool, torrent_search: &TorrentSearch) -> Result<Value> {
     let search_results = sqlx::query!(
         r#"


### PR DESCRIPTION
The goal is to have all api response types defined, to then use a package that translates either rust structs or openapi references into typescript types.

Here, the created struct `SeriesAndTitleGroupHierarchyLite` is only used in the api docs, and not used to deserialize sql query results, as they are already in json format. That provides better performance, but doesn't check if the struct is updated, if someone updates the sql query.

should clear https://github.com/Arcadia-Solutions/arcadia/issues/20