### PR TITLE
swagger: also embed swagger-ui in debug mode

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -30,7 +30,7 @@ actix-http = "3.10.0"
 env_logger = "0.11.8"
 thiserror = "2.0.12"
 utoipa = { version = "5.3.1", features = ["actix_extras"] }
-utoipa-swagger-ui = { version = "9.0.1", features = ["actix-web"] }
+utoipa-swagger-ui = { version = "9.0.1", features = ["actix-web", "debug-embed"] }
 utoipa-actix-web = "0.1.2"
 dotenvy = "0.15.7"
 percent-encoding = "2.3.1"


### PR DESCRIPTION
The `swagger-ui` was only loading in release mode, but configure `utoipa-swagger-ui` to also embed the downloaded swagger ui image into the debug build.