### PR TITLE
tracker: fix passkey in downloaded torrent

### DIFF
--- a/backend/src/repositories/torrent_repository.rs
+++ b/backend/src/repositories/torrent_repository.rs
@@ -187,7 +187,8 @@ pub async fn get_torrent(
     let info = Info::from_bytes(torrent.info_dict).map_err(|_| Error::TorrentFileInvalid)?;
 
     let tracker_url = {
-        let passkey = ((user.passkey_upper as u128) << 64) | (user.passkey_lower as u128);
+        let passkey =
+            ((user.passkey_upper as u64 as u128) << 64) | (user.passkey_lower as u64 as u128);
 
         format!("{}announce/{:x}", tracker_url, passkey)
     };


### PR DESCRIPTION
Postgres only supports signed integer types, which is why we always get a signed type back.  And yet, we interpret the bits as unsigned (or at least should have been!).

So, sign-extension strikes again.  If the lower portion of the passkey had the highest-order bit set, when casted to u128, all of the upper bits are set to 1, meaning the upper bits are wiped.

Fix this just by ensuring the bits are unsigned before extension.