### PR TITLE
tracker: fix peer list in announce

### DIFF
--- a/backend/src/handlers/announce_handler.rs
+++ b/backend/src/handlers/announce_handler.rs
@@ -149,7 +149,7 @@ async fn handle_announce(
     }
 
     let resp = announce::AnnounceResponse {
-        peers,
+        peers: peers.into(),
         ..Default::default()
     };
 

--- a/backend/src/repositories/peer_repository.rs
+++ b/backend/src/repositories/peer_repository.rs
@@ -1,6 +1,6 @@
 use sqlx::{PgPool, types::ipnetwork::IpNetwork};
 
-use crate::tracker::announce::{self, Announce, PeerCompact};
+use crate::tracker::announce::{self, Announce, Peer};
 
 pub async fn remove_peer(
     pool: &PgPool,
@@ -75,11 +75,7 @@ pub async fn insert_or_update_peer(
         .unwrap_or((0, 0))
 }
 
-pub async fn find_torrent_peers(
-    pool: &PgPool,
-    torrent_id: &i64,
-    user_id: &i64,
-) -> Vec<PeerCompact> {
+pub async fn find_torrent_peers(pool: &PgPool, torrent_id: &i64, user_id: &i64) -> Vec<Peer> {
     let peers = sqlx::query!(
         r#"
         SELECT peers.ip AS ip, peers.port AS port
@@ -96,8 +92,6 @@ pub async fn find_torrent_peers(
     .await
     .expect("failed");
 
-    println!("{:?}", peers);
-
     peers
         .into_iter()
         .map(|p| {
@@ -105,7 +99,7 @@ pub async fn find_torrent_peers(
                 panic!("oops");
             };
 
-            announce::PeerCompact {
+            announce::Peer {
                 ip: ipv4,
                 port: p.port as u16,
             }

--- a/backend/tests/test_announce.rs
+++ b/backend/tests/test_announce.rs
@@ -122,7 +122,7 @@ async fn test_announce_known_torrent(pool: PgPool) {
         .expect("could not deserialize announce response");
 
     // There are no peers, so should be empty.
-    assert!(resp.peers.is_empty());
+    assert!(resp.peers.0.is_empty());
 }
 
 #[sqlx::test(fixtures(
@@ -165,9 +165,9 @@ async fn test_announce_known_torrent_with_peers(pool: PgPool) {
         .expect("could not deserialize announce response");
 
     // Fixture sets up two non-self peers.
-    assert!(resp.peers.len() == 2);
+    assert!(resp.peers.0.len() == 2);
 
-    for announce::PeerCompact { ip, port } in &resp.peers {
+    for announce::Peer { ip, port } in &resp.peers.0 {
         assert_ne!(
             (ip, port),
             (&std::net::Ipv4Addr::new(10, 10, 4, 88), &6968),


### PR DESCRIPTION
The announce response from the tracker needs to ensure that the "peers" field in the dict encodes the peers into a (byte)string.  Previously, the tracker was instead encoding the peers as a list of 6-byte strings, but that was incorrect, which caused torrent clients to ignore the peer list.

With this fix, we can actually connect peers together :-)