### PR TITLE
Add trailing slash to example Swagger API url for consistency

### DIFF
--- a/backend/CONTRIBUTING.md
+++ b/backend/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Now when you make changes to the backend, compose will automatically rebuild the
 
 API calls are forwarded to `handlers`, database requests are done by `repositories`, objects are defined by `models`. Directories with those names contain the relevant code.
 
-A swagger for the API is available at `http://localhost:8080/swagger-ui`
+A swagger for the API is available at `http://localhost:8080/swagger-ui/`
 
 If you make changes to structs that are listed in the swagger, you must regenerate the typescript interfaces with this command (from the frontend directory, while the backend is running) :
 


### PR DESCRIPTION
This updates the documentation to use `http://localhost:8080/swagger-ui/` instead of `http://localhost:8080/swagger-ui` to prevent `HTTP ERROR 404` when accessing Swagger locally or via docker.

Why the trailing slash matters:
The route is configured using this wildcard pattern:
```
SwaggerUi::new("/swagger-ui/{_:.*}")
```
Whilst this may appear to support `/swagger-ui` and `/swagger-ui/`, the trailing slash is required for the correct loading of the Swagger UI.

Without the `/`, browsers will fail to load the interface. 
```
INFO  actix_web::middleware::logger] "GET /swagger-ui HTTP/1.1" 404 0 "-" "Mozilla/5.0...
```
http://localhost:8080/swagger-ui ----> HTTP 404 Error
http://localhost:8080/swagger-ui/ ---> Fully functional Swagger UI