### PR TITLE
Devcontainers?

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 			"installDockerBuildx": true,
 			"installDockerComposeSwitch": true,
 			"version": "latest",
-			"dockerDashComposeVersion": "v2"
+			"dockerDashComposeVersion": "none"
 		},
 		"ghcr.io/devcontainers/features/node:1": {
 			"nodeGypDependencies": true,
@@ -22,6 +22,10 @@
 		"ghcr.io/devcontainers/features/rust:1": {
 			"version": "latest",
 			"profile": "minimal"
+		},
+		"ghcr.io/devcontainers/features/github-cli:1": {
+			"installDirectlyFromGitHubRelease": true,
+			"version": "latest"
 		}
 	}
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,6 +27,19 @@
 			"installDirectlyFromGitHubRelease": true,
 			"version": "latest"
 		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-azuretools.vscode-containers",
+				"docker.docker",
+				"dotenv.dotenv-vscode",
+				"EditorConfig.EditorConfig",
+				"redhat.vscode-yaml",
+				"Vue.volar",
+				"tamasfe.even-better-toml"
+			]
+		}
 	}
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Debian",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+			"moby": true,
+			"installDockerBuildx": true,
+			"installDockerComposeSwitch": true,
+			"version": "latest",
+			"dockerDashComposeVersion": "v2"
+		},
+		"ghcr.io/devcontainers/features/node:1": {
+			"nodeGypDependencies": true,
+			"installYarnUsingApt": true,
+			"version": "lts",
+			"pnpmVersion": "latest",
+			"nvmVersion": "latest"
+		},
+		"ghcr.io/devcontainers/features/rust:1": {
+			"version": "latest",
+			"profile": "minimal"
+		}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+    "recommendations": [
+        "ms-azuretools.vscode-containers",
+        "docker.docker",
+        "dotenv.dotenv-vscode",
+        "editorconfig.editorconfig",
+        "dbaeumer.vscode-eslint",
+        "redhat.vscode-yaml",
+        "vue.volar",
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml"
+    ]
+}


### PR DESCRIPTION
This adds configurations for [devcontainers](https://containers.dev/) which is a neat way of having (basically) reproducible developer environments across many machines while also keeping it as isolated as containers (at least by default) are.

Although you can make one for yourself, this would essentially standardize the whole environment thing with all the dependencies required to build Arcadia.

I don't know if you think that what i did here is good enough so i'm leaving it up to you.
Oh and currently you can't bind mount a thing in your workspace inside the container when using the host's Docker instance. Don't know if using the host's workspace would be better and as a person with capped bandwidth internet I'd try to avoid adding more to the download size **just** for the devcontainer by putting a Docker instance inside the container.
[Yes, you can do that!](https://github.com/devcontainers/features/blob/main/src/docker-in-docker) [Like really, you can run Docker in Docker!](https://hub.docker.com/_/docker)