### PR TITLE
Add .gitattributes to /backend (#181)

### DIFF
--- a/backend/.gitattributes
+++ b/backend/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Added a .gitattributes file under /backend and specified that *.sh
should have LF line endings. This fixes a bug where
backend/scripts/init_db.sh would fial to run.

Addresses #181 
