### PR TITLE
fix(init_db): add retry logic for database connection

### DIFF
--- a/backend/scripts/init_db.sh
+++ b/backend/scripts/init_db.sh
@@ -7,4 +7,21 @@ if [ -z ${DATABASE_URL+x} ]; then
   exit 1;
 fi
 
-cargo sqlx database setup --source ./migrations
+# Add retry logic
+max_attempts=30
+attempt=1
+
+while [ $attempt -le $max_attempts ]; do
+  echo "Attempt $attempt: Trying to connect to database..."
+  if cargo sqlx database setup --source ./migrations; then
+    echo "Database setup successful!"
+    exit 0
+  else
+    echo "Database connection failed, retrying in 2 seconds..."
+    sleep 2
+    attempt=$((attempt + 1))
+  fi
+done
+
+echo "Failed to connect to database after $max_attempts attempts"
+exit 1


### PR DESCRIPTION
The script previously failed immediately if the database wasn't available. Added retry logic with 30 attempts and 2-second intervals between retries to handle temporary database unavailability during startup.

Exit with success only after successful connection, or failure after all attempts are exhausted.