### PR TITLE
Enhance docker config for quicker build/deploy

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -55,3 +55,7 @@ TASK_INTERVAL_REMOVE_INACTIVE_PEERS="0 0 * * * *"
 # SMTP_PASSWORD=your-app-password
 # SMTP_FROM_EMAIL=noreply@yourtracker.com
 # SMTP_FROM_NAME=Arcadia Tracker
+
+# Docker buildkit support 
+DOCKER_BUILDKIT=1
+COMPOSE_DOCKER_CLI_BUILD=1

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,6 +19,7 @@ COPY Cargo.toml Cargo.lock ./
 # Helps speed up repetitive docker builds by A LOT
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/registry \
     apt-get update && apt-get install -y libssl-dev openssl curl pkg-config
 
 COPY migrations/ migrations/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,6 +20,7 @@ COPY Cargo.toml Cargo.lock ./
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
     apt-get update && apt-get install -y libssl-dev openssl curl pkg-config
 
 COPY migrations/ migrations/

--- a/compose.yml
+++ b/compose.yml
@@ -42,6 +42,9 @@ services:
         condition: service_healthy
   backend:
     container_name: arcadia_backend
+    volumes:
+      - cargo-registry:/usr/local/cargo/registry
+      - cargo-target:/app/target
     build:
       context: backend
       dockerfile: Dockerfile
@@ -92,3 +95,5 @@ services:
 
 volumes:
   db_data:
+  cargo-registry:
+  cargo-target:


### PR DESCRIPTION
Updated the docker config to support docker [BuildKit](https://docs.docker.com/build/buildkit/) for quicker builds and deployments by using layer caching.

Includes a modification to the sample .env file to enable BuildKit, as it cannot be strictly enforced on a repository level. 
