### PR TITLE
Fix-scrollbars for chromium browsers

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -100,7 +100,7 @@ router.isReady().then(async () => {
 
 <style>
 .navbars-container {
-  width: 100vw;
+  width: 100%;
 }
 .menu-bar {
   margin-top: 10px;
@@ -111,6 +111,6 @@ router.isReady().then(async () => {
 }
 #footer {
   margin-top: auto;
-  width: 100vw;
+  width: 100%;
 }
 </style>


### PR DESCRIPTION
The issue is present on all chromium based browsers such as: Edge, google chrome and indeed brave.
The issue is not present on Firefox and browsers based off its codebase.
This is because Firefox hides overflow in the x direction whereas chromium based browsers will just show it.

The only case of overflow I was able to find presently was horizontal in the torrents page due to vh causing the lengths of some objects to be too big.
Adjusting these to 100% seems to solve the issue.

 