### PR TITLE
Chore/jwt middleware

### DIFF
--- a/backend/api/src/handlers/affiliated_artists/mod.rs
+++ b/backend/api/src/handlers/affiliated_artists/mod.rs
@@ -1,11 +1,14 @@
 pub mod create_affiliated_artists;
 pub mod remove_affiliated_artists;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{delete, post, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
         resource("")
+            .wrap(HttpAuthentication::with_fn(authenticate_user))
             .route(post().to(self::create_affiliated_artists::exec))
             .route(delete().to(self::remove_affiliated_artists::exec)),
     );

--- a/backend/api/src/handlers/artists/mod.rs
+++ b/backend/api/src/handlers/artists/mod.rs
@@ -1,12 +1,18 @@
 pub mod create_artists;
 pub mod get_artist_publications;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{get, post, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
         resource("")
-            .route(post().to(self::create_artists::exec))
+            .route(
+                post()
+                    .to(self::create_artists::exec)
+                    .wrap(HttpAuthentication::with_fn(authenticate_user)),
+            )
             .route(get().to(self::get_artist_publications::exec)),
     );
 }

--- a/backend/api/src/handlers/conversations/mod.rs
+++ b/backend/api/src/handlers/conversations/mod.rs
@@ -2,14 +2,23 @@ pub mod create_conversation;
 pub mod create_conversation_message;
 pub mod get_conversation;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{get, post, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
         resource("")
+            .wrap(HttpAuthentication::with_fn(authenticate_user))
             .route(post().to(self::create_conversation::exec))
             .route(get().to(self::get_conversation::exec)),
     );
 
-    cfg.service(resource("/messages").route(post().to(self::create_conversation_message::exec)));
+    cfg.service(
+        resource("/messages").route(
+            post()
+                .to(self::create_conversation_message::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
 }

--- a/backend/api/src/handlers/edition_groups/mod.rs
+++ b/backend/api/src/handlers/edition_groups/mod.rs
@@ -1,6 +1,15 @@
 pub mod create_edition_group;
+
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{get, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
-    cfg.service(resource("").route(get().to(self::create_edition_group::exec)));
+    cfg.service(
+        resource("").route(
+            get()
+                .to(self::create_edition_group::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
 }

--- a/backend/api/src/handlers/forum/mod.rs
+++ b/backend/api/src/handlers/forum/mod.rs
@@ -4,16 +4,28 @@ pub mod get_forum;
 pub mod get_forum_sub_category_threads;
 pub mod get_forum_thread;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{get, post, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(resource("").route(get().to(self::get_forum::exec)));
     cfg.service(
         resource("/thread")
             .route(get().to(self::get_forum_thread::exec))
-            .route(post().to(self::create_forum_thread::exec)),
+            .route(
+                post()
+                    .to(self::create_forum_thread::exec)
+                    .wrap(HttpAuthentication::with_fn(authenticate_user)),
+            ),
     );
-    cfg.service(resource("/post").route(get().to(self::create_forum_post::exec)));
+    cfg.service(
+        resource("/post").route(
+            get()
+                .to(self::create_forum_post::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
     cfg.service(
         resource("/sub-category").route(get().to(self::get_forum_sub_category_threads::exec)),
     );

--- a/backend/api/src/handlers/gifts/mod.rs
+++ b/backend/api/src/handlers/gifts/mod.rs
@@ -1,7 +1,15 @@
 pub mod create_gift;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{post, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
-    cfg.service(resource("").route(post().to(self::create_gift::exec)));
+    cfg.service(
+        resource("").route(
+            post()
+                .to(self::create_gift::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
 }

--- a/backend/api/src/handlers/invitations/mod.rs
+++ b/backend/api/src/handlers/invitations/mod.rs
@@ -1,7 +1,15 @@
 pub mod create_invitation;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{post, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
-    cfg.service(resource("").route(post().to(self::create_invitation::exec)));
+    cfg.service(
+        resource("").route(
+            post()
+                .to(self::create_invitation::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
 }

--- a/backend/api/src/handlers/master_groups/mod.rs
+++ b/backend/api/src/handlers/master_groups/mod.rs
@@ -1,7 +1,15 @@
 pub mod create_master_group;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{post, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
-    cfg.service(resource("").route(post().to(self::create_master_group::exec)));
+    cfg.service(
+        resource("").route(
+            post()
+                .to(self::create_master_group::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
 }

--- a/backend/api/src/handlers/search/mod.rs
+++ b/backend/api/src/handlers/search/mod.rs
@@ -4,13 +4,21 @@ pub mod search_title_group_info_lite;
 pub mod search_torrent_requests;
 pub mod search_torrents;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{post, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
         resource("/title-groups/lite").route(post().to(self::search_title_group_info_lite::exec)),
     );
-    cfg.service(resource("/torrents/lite").route(post().to(self::search_torrents::exec)));
+    cfg.service(
+        resource("/torrents/lite").route(
+            post()
+                .to(self::search_torrents::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
     cfg.service(resource("/artists/lite").route(post().to(self::search_artists_lite::exec)));
     cfg.service(
         resource("/torrent-requests").route(post().to(self::search_torrent_requests::exec)),

--- a/backend/api/src/handlers/series/mod.rs
+++ b/backend/api/src/handlers/series/mod.rs
@@ -1,12 +1,18 @@
 pub mod create_series;
 pub mod get_series;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{get, post, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
         resource("")
-            .route(post().to(self::create_series::exec))
+            .route(
+                post()
+                    .to(self::create_series::exec)
+                    .wrap(HttpAuthentication::with_fn(authenticate_user)),
+            )
             .route(get().to(self::get_series::exec)),
     );
 }

--- a/backend/api/src/handlers/subscriptions/mod.rs
+++ b/backend/api/src/handlers/subscriptions/mod.rs
@@ -1,11 +1,14 @@
 pub mod create_subscription;
 pub mod remove_subscription;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{delete, post, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
         resource("")
+            .wrap(HttpAuthentication::with_fn(authenticate_user))
             .route(post().to(self::create_subscription::exec))
             .route(delete().to(self::remove_subscription::exec)),
     );

--- a/backend/api/src/handlers/title_groups/mod.rs
+++ b/backend/api/src/handlers/title_groups/mod.rs
@@ -4,15 +4,24 @@ pub mod edit_title_group;
 pub mod get_title_group;
 pub mod get_title_group_info_lite;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{get, post, put, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
         resource("")
+            .wrap(HttpAuthentication::with_fn(authenticate_user))
             .route(post().to(self::create_title_group::exec))
             .route(get().to(self::get_title_group::exec))
             .route(put().to(self::edit_title_group::exec)),
     );
     cfg.service(resource("/lite").route(post().to(self::get_title_group_info_lite::exec)));
-    cfg.service(resource("/comments").route(post().to(self::create_title_group_comment::exec)));
+    cfg.service(
+        resource("/comments").route(
+            post()
+                .to(self::create_title_group_comment::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
 }

--- a/backend/api/src/handlers/torrent_requests/mod.rs
+++ b/backend/api/src/handlers/torrent_requests/mod.rs
@@ -3,14 +3,29 @@ pub mod create_torrent_request_vote;
 pub mod fill_torrent_request;
 pub mod get_torrent_request;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{get, post, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
         resource("")
+            .wrap(HttpAuthentication::with_fn(authenticate_user))
             .route(post().to(self::create_torrent_request::exec))
             .route(get().to(self::get_torrent_request::exec)),
     );
-    cfg.service(resource("/fill").route(post().to(self::fill_torrent_request::exec)));
-    cfg.service(resource("/vote").route(post().to(self::create_torrent_request_vote::exec)));
+    cfg.service(
+        resource("/fill").route(
+            post()
+                .to(self::fill_torrent_request::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
+    cfg.service(
+        resource("/vote").route(
+            post()
+                .to(self::create_torrent_request_vote::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
 }

--- a/backend/api/src/handlers/torrents/mod.rs
+++ b/backend/api/src/handlers/torrents/mod.rs
@@ -7,18 +7,39 @@ pub mod get_registered_torrents;
 pub mod get_top_torrents;
 pub mod get_upload_information;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{delete, get, post, put, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
         resource("")
+            .wrap(HttpAuthentication::with_fn(authenticate_user))
             .route(post().to(self::create_torrent::exec))
             .route(get().to(self::download_dottorrent_file::exec))
             .route(put().to(self::edit_torrent::exec))
             .route(delete().to(self::delete_torrent::exec)),
     );
-    cfg.service(resource("/registered").route(get().to(self::get_registered_torrents::exec)));
-    cfg.service(resource("/upload-info").route(get().to(self::get_upload_information::exec)));
+    cfg.service(
+        resource("/registered").route(
+            get()
+                .to(self::get_registered_torrents::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
+    cfg.service(
+        resource("/upload-info").route(
+            get()
+                .to(self::get_upload_information::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
     cfg.service(resource("/top").route(get().to(self::get_top_torrents::exec)));
-    cfg.service(resource("/reports").route(get().to(self::create_torrent_report::exec)));
+    cfg.service(
+        resource("/reports").route(
+            get()
+                .to(self::create_torrent_report::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
 }

--- a/backend/api/src/handlers/user_applications/mod.rs
+++ b/backend/api/src/handlers/user_applications/mod.rs
@@ -2,13 +2,23 @@ pub mod create_user_application;
 pub mod get_user_applications;
 pub mod update_user_application_status;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{get, post, put, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
         resource("")
             .route(post().to(self::create_user_application::exec))
-            .route(get().to(self::get_user_applications::exec))
-            .route(put().to(self::update_user_application_status::exec)),
+            .route(
+                get()
+                    .to(self::get_user_applications::exec)
+                    .wrap(HttpAuthentication::with_fn(authenticate_user)),
+            )
+            .route(
+                put()
+                    .to(self::update_user_application_status::exec)
+                    .wrap(HttpAuthentication::with_fn(authenticate_user)),
+            ),
     );
 }

--- a/backend/api/src/handlers/users/mod.rs
+++ b/backend/api/src/handlers/users/mod.rs
@@ -6,17 +6,48 @@ pub mod get_user;
 pub mod get_user_conversations;
 pub mod warn_user;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{get, post, put, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
         resource("")
             .route(get().to(self::get_user::exec))
-            .route(put().to(self::edit_user::exec)),
+            .route(put().to(self::edit_user::exec))
+            .wrap(HttpAuthentication::with_fn(authenticate_user)),
     );
-    cfg.service(resource("/warnings").route(post().to(self::warn_user::exec)));
-    cfg.service(resource("/me").route(get().to(self::get_me::exec)));
-    cfg.service(resource("/registered").route(get().to(self::get_registered_users::exec)));
-    cfg.service(resource("/api-keys").route(post().to(self::create_api_key::exec)));
-    cfg.service(resource("/conversations").route(get().to(self::get_user_conversations::exec)));
+    cfg.service(
+        resource("/warnings").route(
+            post()
+                .to(self::warn_user::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
+    cfg.service(
+        resource("/me").route(
+            get()
+                .to(self::get_me::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
+    cfg.service(
+        resource("/registered").route(
+            get()
+                .to(self::get_registered_users::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
+    cfg.service(
+        resource("/api-keys")
+            .route(post().to(self::create_api_key::exec))
+            .wrap(HttpAuthentication::with_fn(authenticate_user)),
+    );
+    cfg.service(
+        resource("/conversations").route(
+            get()
+                .to(self::get_user_conversations::exec)
+                .wrap(HttpAuthentication::with_fn(authenticate_user)),
+        ),
+    );
 }

--- a/backend/api/src/handlers/wiki/mod.rs
+++ b/backend/api/src/handlers/wiki/mod.rs
@@ -1,12 +1,18 @@
 pub mod create_wiki_article;
 pub mod get_wiki_article;
 
+use crate::middlewares::jwt_middleware::authenticate_user;
 use actix_web::web::{get, post, resource, ServiceConfig};
+use actix_web_httpauth::middleware::HttpAuthentication;
 
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
         resource("/articles")
-            .route(post().to(self::create_wiki_article::exec))
+            .route(
+                post()
+                    .to(self::create_wiki_article::exec)
+                    .wrap(HttpAuthentication::with_fn(authenticate_user)),
+            )
             .route(get().to(self::get_wiki_article::exec)),
     );
 }

--- a/backend/api/src/middlewares/jwt_middleware.rs
+++ b/backend/api/src/middlewares/jwt_middleware.rs
@@ -8,17 +8,6 @@ pub async fn authenticate_user(
     req: ServiceRequest,
     bearer: Option<BearerAuth>,
 ) -> std::result::Result<ServiceRequest, (actix_web::Error, ServiceRequest)> {
-    // These routes are explicitly not authenticated.
-    if matches!(
-        req.path(),
-        "/api/auth/login"
-            | "/api/auth/register"
-            | "/api/auth/refresh-token"
-            | "/api/user-applications"
-    ) {
-        return Ok(req);
-    }
-
     if let Some(bearer) = bearer {
         validate_bearer_auth(req, bearer).await
     } else if let Some(api_key) = req.headers().get("api_key") {

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -1,5 +1,4 @@
 use actix_web::web::{self, scope};
-use actix_web_httpauth::middleware::HttpAuthentication;
 
 use crate::handlers::affiliated_artists::config as AffiliatedArtistsConfig;
 use crate::handlers::announces::config as AnnouncesConfig;
@@ -22,14 +21,12 @@ use crate::handlers::torrents::config as TorrentsConfig;
 use crate::handlers::user_applications::config as UserApplicationsConfig;
 use crate::handlers::users::config as UsersConfig;
 use crate::handlers::wiki::config as WikiConfig;
-use crate::middlewares::jwt_middleware::authenticate_user;
 
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(scope("/announce").configure(AnnouncesConfig));
 
     cfg.service(
         web::scope("/api")
-            .wrap(HttpAuthentication::with_fn(authenticate_user))
             .service(scope("/auth").configure(AuthConfig))
             .service(scope("/users").configure(UsersConfig))
             .service(scope("/user-applications").configure(UserApplicationsConfig))


### PR DESCRIPTION
Add explicit auth guards (middleware) to each endpoint that requires authentication. At the moment the way we define guarded endpoint is by excluding them in the `jwt_middleware`. But this is error prone since we're delaing with arbitrary string. By making such checks declarative in the code we avoid errors.