### PR TITLE
Fix wrong HTTP method from create edition: change from get to post

### DIFF
--- a/backend/api/src/handlers/edition_groups/mod.rs
+++ b/backend/api/src/handlers/edition_groups/mod.rs
@@ -1,7 +1,7 @@
 pub mod create_edition_group;
-use actix_web::web::{get, resource, ServiceConfig};
+use actix_web::web::{post, resource, ServiceConfig};
 use arcadia_storage::redis::RedisPoolInterface;
 
 pub fn config<R: RedisPoolInterface + 'static>(cfg: &mut ServiceConfig) {
-    cfg.service(resource("").route(get().to(self::create_edition_group::exec::<R>)));
+    cfg.service(resource("").route(post().to(self::create_edition_group::exec::<R>)));
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP method for the create_edition_group API: now accepts POST requests instead of GET when creating an edition group. This aligns with standard REST behavior and may require client updates. Existing GET requests will no longer work—update integrations, SDKs, and scripts accordingly. No other behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->