### PR TITLE
Refactored the edit_torrent and edit_title_group

### DIFF
--- a/backend/api/src/handlers/title_groups/edit_title_group.rs
+++ b/backend/api/src/handlers/title_groups/edit_title_group.rs
@@ -32,10 +32,10 @@ pub async fn exec<R: RedisPoolInterface + 'static>(
 ) -> Result<HttpResponse> {
     let title_group = arc.pool.find_title_group(form.id).await?;
 
-    if user.class == UserClass::Staff || title_group.created_by_id == user.sub {
-        let updated_title_group = arc.pool.update_title_group(&form, title_group.id).await?;
-        return Ok(HttpResponse::Ok().json(updated_title_group));
+    if user.class != UserClass::Staff && title_group.created_by_id != user.sub {
+        return Err(Error::InsufficientPrivileges);
     }
 
-    Err(Error::InsufficientPrivileges)
+    let updated_title_group = arc.pool.update_title_group(&form, title_group.id).await?;
+    Ok(HttpResponse::Ok().json(updated_title_group))
 }

--- a/backend/api/src/handlers/torrents/edit_torrent.rs
+++ b/backend/api/src/handlers/torrents/edit_torrent.rs
@@ -32,10 +32,10 @@ pub async fn exec<R: RedisPoolInterface + 'static>(
 ) -> Result<HttpResponse> {
     let torrent = arc.pool.find_torrent(form.id).await?;
 
-    if user.class == UserClass::Staff || torrent.created_by_id == user.sub {
-        let updated_torrent = arc.pool.update_torrent(&form, torrent.id).await?;
-        return Ok(HttpResponse::Ok().json(updated_torrent));
+    if user.class != UserClass::Staff && torrent.created_by_id != user.sub {
+        return Err(Error::InsufficientPrivileges);
     }
 
-    Err(Error::InsufficientPrivileges)
+    let updated_torrent = arc.pool.update_torrent(&form, torrent.id).await?;
+    Ok(HttpResponse::Ok().json(updated_torrent))
 }


### PR DESCRIPTION
Refactored the edit_torrent and edit_title_group to more efficiently handle the user/staff privilege test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized permission checks for editing title groups and torrents using a consistent guard pattern.
  * Streamlined control flow to reduce branching and ensure a single, clear success path.
  * Maintains existing behavior: authorized users can edit; unauthorized users receive an insufficient privileges error.
  * Improves consistency and reliability of authorization handling across related endpoints.
  * No user-facing feature changes; expected to enhance maintainability and reduce potential edge-case inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->