### PR TITLE
Add latest posts

### DIFF
--- a/backend/api/src/handlers/forum/get_forum.rs
+++ b/backend/api/src/handlers/forum/get_forum.rs
@@ -2,6 +2,7 @@ use crate::Arcadia;
 use actix_web::{web::Data, HttpResponse};
 use arcadia_common::error::Result;
 use arcadia_storage::{models::forum::ForumOverview, redis::RedisPoolInterface};
+use serde_json::json;
 
 #[utoipa::path(
     get,
@@ -15,6 +16,10 @@ use arcadia_storage::{models::forum::ForumOverview, redis::RedisPoolInterface};
 pub async fn exec<R: RedisPoolInterface + 'static>(arc: Data<Arcadia<R>>) -> Result<HttpResponse> {
     //TODO: restrict access to some sub_categories based on forbidden_classes
     let forum_overview = arc.pool.find_forum_overview().await?;
+    let latest_forum_posts = arc.pool.find_latest_forum_posts(3).await?;
 
-    Ok(HttpResponse::Ok().json(forum_overview))
+    Ok(HttpResponse::Ok().json(json!({
+        "forum_overview": forum_overview,
+        "latest_forum_posts": latest_forum_posts,
+    })))
 }

--- a/backend/storage/.sqlx/query-3c00fa040778d32b8ea960ce54c5bfc5a134cb99705f2bc1fd980c05bfce5da6.json
+++ b/backend/storage/.sqlx/query-3c00fa040778d32b8ea960ce54c5bfc5a134cb99705f2bc1fd980c05bfce5da6.json
@@ -1,0 +1,94 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT \n                fp.id,\n                fp.forum_thread_id,\n                fp.created_at as \"created_at!\",\n                fp.updated_at as \"updated_at!\",\n                fp.content,\n                fp.sticky,\n                ft.name as \"forum_thread_name\",\n                fsc.id as \"forum_sub_category_id\",\n                fsc.name as \"forum_sub_category_name\",\n                fc.id as \"forum_category_id\",\n                fc.name as \"forum_category_name\",\n                u.id as \"created_by_id!\",\n                u.username as \"created_by_username!\"\n            FROM\n                forum_posts fp\n            JOIN\n                forum_threads ft ON fp.forum_thread_id = ft.id\n            JOIN\n                forum_sub_categories fsc ON ft.forum_sub_category_id = fsc.id\n            JOIN\n                forum_categories fc ON fsc.forum_category_id = fc.id\n            JOIN\n                users u ON fp.created_by_id = u.id\n            ORDER BY\n                fp.created_at DESC\n            LIMIT $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "forum_thread_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "updated_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "content",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "sticky",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "forum_thread_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "forum_sub_category_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "forum_sub_category_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "forum_category_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "forum_category_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "created_by_id!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 12,
+        "name": "created_by_username!",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3c00fa040778d32b8ea960ce54c5bfc5a134cb99705f2bc1fd980c05bfce5da6"
+}

--- a/backend/storage/src/models/forum.rs
+++ b/backend/storage/src/models/forum.rs
@@ -158,3 +158,22 @@ pub struct ForumPostAndThreadName {
     pub sticky: bool,
     pub forum_thread_name: String,
 }
+
+#[derive(Debug, Deserialize, Serialize, FromRow, ToSchema)]
+pub struct LatestForumPost {
+    pub id: i64,
+    pub forum_thread_id: i64,
+    #[schema(value_type = String, format = DateTime)]
+    pub created_at: DateTime<Local>,
+    #[schema(value_type = String, format = DateTime)]
+    pub updated_at: DateTime<Local>,
+    pub content: String,
+    pub sticky: bool,
+    pub forum_thread_name: String,
+    pub forum_sub_category_id: i32,
+    pub forum_sub_category_name: String,
+    pub forum_category_id: i32,
+    pub forum_category_name: String,
+    pub created_by_id: i64,
+    pub created_by_username: String,
+}

--- a/frontend/src/components/community/BBCodeRenderer.vue
+++ b/frontend/src/components/community/BBCodeRenderer.vue
@@ -19,6 +19,10 @@ const parsedContent = computed(() => {
 .bbcode-content {
   width: 100%;
   overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
+  hyphens: auto;
+  white-space: pre-wrap;
 }
 
 .bbcode-content :deep(img) {

--- a/frontend/src/components/forum/LatestForumPosts.vue
+++ b/frontend/src/components/forum/LatestForumPosts.vue
@@ -1,0 +1,68 @@
+<template>
+  <ContentContainer :containerTitle="t('forum.latest_posts')" v-if="latestPosts && latestPosts.length > 0">
+    <DataTable :value="latestPosts" class="latest-posts-table">
+      <Column field="forum_thread_name" :header="t('general.title')" style="width: 30%">
+        <template #body="slotProps">
+          <RouterLink :to="`/forum/thread/${slotProps.data.forum_thread_id}`">
+            {{ slotProps.data.forum_thread_name }}
+          </RouterLink>
+        </template>
+      </Column>
+      <Column field="content" :header="t('general.content')" style="width: 30%">
+        <template #body="slotProps">
+          {{ truncateContent(slotProps.data.content) }}
+        </template>
+      </Column>
+      <Column field="created_at" :header="t('forum.latest_post')" style="width: 25%">
+        <template #body="slotProps">
+          {{ timeAgo(slotProps.data.created_at) }} {{ t('general.by') }}
+          <RouterLink :to="`/user/${slotProps.data.created_by_id}`">
+            {{ slotProps.data.created_by_username }}
+          </RouterLink>
+        </template>
+      </Column>
+      <Column field="forum_sub_category_name" :header="t('general.category')" style="width: 15%">
+        <template #body="slotProps">
+          <RouterLink :to="`/forum/sub-category/${slotProps.data.forum_sub_category_id}`">
+            {{ slotProps.data.forum_sub_category_name }}
+          </RouterLink>
+        </template>
+      </Column>
+    </DataTable>
+  </ContentContainer>
+</template>
+
+<script setup lang="ts">
+import ContentContainer from '@/components/ContentContainer.vue'
+import { useI18n } from 'vue-i18n'
+import { RouterLink } from 'vue-router'
+import { timeAgo } from '@/services/helpers'
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import type { LatestForumPost } from '@/services/api/homeService'
+
+const { t } = useI18n()
+
+defineProps<{
+  latestPosts: LatestForumPost[]
+}>()
+
+const truncateContent = (content: string, maxLength = 100) => {
+  const cleanContent = content.replace(/\[.*?\]/g, '').trim()
+  return cleanContent.length <= maxLength ? cleanContent : cleanContent.substring(0, maxLength) + '...'
+}
+</script>
+
+<style scoped>
+.latest-posts-table :deep(.p-datatable-tbody > tr > td) {
+  padding: 0.5rem 0.75rem;
+}
+
+.latest-posts-table :deep(.p-datatable-thead > tr > th) {
+  padding: 0.5rem 0.75rem;
+}
+
+.content-container {
+  margin-top: 15px;
+}
+</style>

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -95,6 +95,7 @@
   "forum": {
     "forum": "Forum | Forums",
     "latest_post": "Latest post",
+    "latest_posts": "Latest Posts",
     "threads": "Threads",
     "posts": "Posts",
     "new_post": "New post",

--- a/frontend/src/services/api/forumService.ts
+++ b/frontend/src/services/api/forumService.ts
@@ -5,8 +5,24 @@ export type ForumOverview = components['schemas']['ForumOverview']
 
 export type ForumCategoryHierarchy = components['schemas']['ForumCategoryHierarchy']
 
-export const getForum = async (): Promise<ForumOverview> => {
-  return (await api.get<ForumOverview>('/forum')).data
+export type LatestForumPost = {
+  id: number
+  forum_thread_id: number
+  created_at: string
+  updated_at: string
+  content: string
+  sticky: boolean
+  forum_thread_name: string
+  forum_sub_category_id: number
+  forum_sub_category_name: string
+  forum_category_id: number
+  forum_category_name: string
+  created_by_id: number
+  created_by_username: string
+}
+
+export const getForum = async () => {
+  return (await api.get('/forum')).data
 }
 
 export type ForumSubCategoryHierarchy = components['schemas']['ForumSubCategoryHierarchy']

--- a/frontend/src/services/api/homeService.ts
+++ b/frontend/src/services/api/homeService.ts
@@ -7,6 +7,22 @@ export type ForumPostAndThreadName = components['schemas']['ForumPostAndThreadNa
 
 export type HomeStats = components['schemas']['HomeStats']
 
+export type LatestForumPost = {
+  id: number
+  forum_thread_id: number
+  created_at: string
+  updated_at: string
+  content: string
+  sticky: boolean
+  forum_thread_name: string
+  forum_sub_category_id: number
+  forum_sub_category_name: string
+  forum_category_id: number
+  forum_category_name: string
+  created_by_id: number
+  created_by_username: string
+}
+
 export const getHome = async () => {
   return (await api.get<HomePage>('/home')).data
 }

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -2,6 +2,7 @@
   <div id="home-page">
     <div class="main">
       <LatestTorrents v-if="latestUploads" containerTitleLink="/torrents" :containerTitle="t('torrent.latest_uploads')" :titleGroups="latestUploads" />
+      <LatestForumPosts v-if="latestForumPosts" :latestPosts="latestForumPosts" />
       <div class="announcements">
         <AnnouncementComponent v-for="announcement in recentAnnouncements" :key="announcement.id" :announcement class="announcement" />
       </div>
@@ -18,7 +19,7 @@
 </template>
 
 <script setup lang="ts">
-import { getHome, type ForumPostAndThreadName, type HomeStats } from '@/services/api/homeService'
+import { getHome, type ForumPostAndThreadName, type HomeStats, type LatestForumPost } from '@/services/api/homeService'
 import { onMounted } from 'vue'
 import { ref } from 'vue'
 import AnnouncementComponent from '@/components/forum/AnnouncementComponent.vue'
@@ -26,16 +27,19 @@ import ContentContainer from '@/components/ContentContainer.vue'
 import { useI18n } from 'vue-i18n'
 import type { TitleGroupLite } from '@/services/api/torrentService'
 import LatestTorrents from '@/components/torrent/LatestTorrents.vue'
+import LatestForumPosts from '@/components/forum/LatestForumPosts.vue'
 
 const { t } = useI18n()
 
 const recentAnnouncements = ref<ForumPostAndThreadName[]>()
+const latestForumPosts = ref<LatestForumPost[]>()
 const stats = ref<HomeStats>()
 const latestUploads = ref<TitleGroupLite[]>()
 
 const fetchHome = async () => {
   getHome().then((data) => {
     recentAnnouncements.value = data.recent_announcements
+    latestForumPosts.value = data.latest_forum_posts
     stats.value = data.stats
     latestUploads.value = data.latest_uploads
   })

--- a/frontend/src/views/forum/ForumOverviewView.vue
+++ b/frontend/src/views/forum/ForumOverviewView.vue
@@ -1,21 +1,25 @@
 <template>
   <ForumSearchForm />
+  <LatestForumPosts v-if="latestForumPosts" :latestPosts="latestForumPosts" />
   <div v-if="forumOverview">
     <ForumCategoryOverview class="forum-category" v-for="category in forumOverview.forum_categories" :key="category.id" :forum-category="category" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { getForum, type ForumOverview } from '@/services/api/forumService'
-import { onMounted } from 'vue'
-import { ref } from 'vue'
+import { getForum, type ForumOverview, type LatestForumPost } from '@/services/api/forumService'
+import { onMounted, ref } from 'vue'
 import ForumCategoryOverview from '@/components/forum/ForumCategoryOverview.vue'
 import ForumSearchForm from '@/components/forum/ForumSearchForm.vue'
+import LatestForumPosts from '@/components/forum/LatestForumPosts.vue'
 
-const forumOverview = ref<null | ForumOverview>(null)
+const forumOverview = ref<ForumOverview | null>(null)
+const latestForumPosts = ref<LatestForumPost[]>([])
 
 onMounted(async () => {
-  forumOverview.value = await getForum()
+  const data = await getForum()
+  forumOverview.value = data.forum_overview
+  latestForumPosts.value = data.latest_forum_posts
 })
 </script>
 


### PR DESCRIPTION
Issue #365 
Added a latest forum posts feature and fixed truncation in BBCodeRenderer.
I am not a good frontend developer so any requests for changes to the UI or how the code is written are welcome, or if you deem any backend code unnecessary for this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added “Latest Posts” section on the Home and Forum Overview pages, showing recent threads with previews, timestamps, authors, and category links.
  * BBCode content now supports collapsible previews with “View more” / “View less,” improving readability of long posts.
  * Added English translations for “Latest Posts,” “View more,” and “View less.”

* Refactor
  * Unified forum data loading to include recent posts alongside the overview for a more informative landing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->