### PR TITLE
fix(tests): correct HTTP method in torrent tests (POST -> GET)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,7 @@ dependencies = [
  "serde_bencode",
  "serde_bytes",
  "serde_json",
+ "serde_urlencoded",
  "sqlx",
  "strum",
  "thiserror 2.0.16",

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -42,6 +42,7 @@ arcadia-common = { path = "../common"}
 arcadia-storage = { path = "../storage"}
 bincode = "2.0.1"
 arcadia-shared = { path = "../../shared" }
+serde_urlencoded = "0.7.1"
 
 [dev-dependencies]
 actix-multipart-rfc7578 = "0.11.0"


### PR DESCRIPTION
Fixed failing tests:
- test_find_torrents_by_external_link
- test_find_torrents_by_name
- test_find_torrents_no_link_or_name_provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API request method for torrent search endpoint to improve request handling and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->