### PR TITLE
Fix username length error message

### DIFF
--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -397,7 +397,7 @@
     "email_required": "Email is required",
     "email_invalid": "Please enter a valid email address",
     "username_required": "Username is required",
-    "username_invalid": "Username must be 4-20 characters (letters, numbers, _-)",
+    "username_invalid": "Username must be 4-15 characters (letters, numbers, _-)",
     "password_required": "Password is required",
     "password_too_short": "Password must be at least 12 characters long",
     "password_no_uppercase": "Password must contain at least one uppercase letter",


### PR DESCRIPTION
Fix https://github.com/Arcadia-Solutions/arcadia/issues/412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the username length validation requirement in authentication messages. Users will now see that usernames must be 4-15 characters (instead of the previous 4-20 character range), with support for letters, numbers, underscores, and hyphens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->