### PR TITLE
fix: prevent home page flash when not logged in

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory, type RouteRecordInfo } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
+import { isRouteProtected } from '../services/helpers'
 
 export interface RouteNamedMap {
   TitleGroup: RouteRecordInfo<'TitleGroup', '/title-group/:id', { id: string | number }>
@@ -282,6 +283,17 @@ const router = createRouter({
       component: () => import('../views/CreateOrEditCssSheetView.vue'),
     },
   ],
+})
+
+// Auth guard: redirect to login if not authenticated on protected routes
+router.beforeEach((to) => {
+  if (isRouteProtected(to.path)) {
+    const token = localStorage.getItem('token')
+    if (!token) {
+      return { path: '/login' }
+    }
+  }
+  return true
 })
 
 export default router


### PR DESCRIPTION
## Summary
- Add router navigation guard to check authentication before component resolution
- Prevents the home page from briefly flashing before redirect to login when the user is not authenticated

## Test plan
- [ ] Clear localStorage and visit `/` - should redirect immediately to `/login`
- [ ] Login and verify normal navigation still works

Fixes #341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication guard to protected routes. Users without valid authentication credentials are automatically redirected to the login page when attempting to access restricted areas of the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->