### PR TITLE
feat: add 404 not found page

### DIFF
--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -455,7 +455,10 @@
     "select_extras": "Select the type(s) of extras",
     "invalid_url": "Invalid url",
     "artist_must_have_at_least_one_role": "Artist must have at least 1 role",
-    "invalid_name": "Invalid name"
+    "invalid_name": "Invalid name",
+    "page_not_found": "Page not found",
+    "back_to_home": "Back to home",
+    "no_seeders": "This page has no seeders..."
   },
   "footer": {
     "site_and_design": "Site and design"

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -281,6 +281,14 @@ const router = createRouter({
       },
       component: () => import('../views/CreateOrEditCssSheetView.vue'),
     },
+    {
+      path: '/:pathMatch(.*)*',
+      name: 'NotFound',
+      meta: {
+        documentTitle: 'Page not found',
+      },
+      component: () => import('../views/NotFoundView.vue'),
+    },
   ],
 })
 

--- a/frontend/src/services/api-schema/configuration.ts
+++ b/frontend/src/services/api-schema/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
+        const jsonMime: RegExp = new RegExp('^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
     }
 }

--- a/frontend/src/views/NotFoundView.vue
+++ b/frontend/src/views/NotFoundView.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="not-found-container">
+    <div class="not-found-content">
+      <div class="error-code">
+        <span class="four">4</span>
+        <span class="zero">
+          <i class="pi pi-spinner spin"></i>
+        </span>
+        <span class="four">4</span>
+      </div>
+      <h2 class="error-title">{{ t('error.page_not_found') }}</h2>
+      <p class="error-message">{{ t('error.no_seeders') }}</p>
+      <div class="error-stats">
+        <span class="stat seeders"> <i class="pi pi-arrow-up"></i> 0 </span>
+        <span class="stat leechers"> <i class="pi pi-arrow-down"></i> 1 </span>
+      </div>
+      <router-link to="/" class="home-button">
+        <i class="pi pi-home"></i>
+        {{ t('error.back_to_home') }}
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+</script>
+
+<style scoped>
+.not-found-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 60vh;
+  padding: 2rem;
+}
+
+.not-found-content {
+  text-align: center;
+  max-width: 500px;
+}
+
+.error-code {
+  font-size: 8rem;
+  font-weight: bold;
+  line-height: 1;
+  margin-bottom: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.four {
+  color: var(--p-primary-color, #60a5fa);
+}
+
+.zero {
+  color: var(--p-red-500, #ef4444);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.zero i {
+  font-size: 6rem;
+}
+
+.spin {
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.error-title {
+  font-size: 1.75rem;
+  margin-bottom: 0.5rem;
+  color: var(--p-text-color);
+}
+
+.error-message {
+  font-size: 1.1rem;
+  color: var(--p-text-muted-color, #9ca3af);
+  margin-bottom: 1.5rem;
+}
+
+.error-stats {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  margin-bottom: 2rem;
+  font-size: 1.25rem;
+}
+
+.stat {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.seeders {
+  color: var(--p-green-500, #22c55e);
+}
+
+.leechers {
+  color: var(--p-red-500, #ef4444);
+}
+
+.home-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  background-color: var(--p-primary-color, #60a5fa);
+  color: var(--p-primary-contrast-color, #fff);
+  border-radius: 0.5rem;
+  text-decoration: none;
+  font-weight: 500;
+  transition: background-color 0.2s;
+}
+
+.home-button:hover {
+  background-color: var(--p-primary-hover-color, #3b82f6);
+}
+</style>


### PR DESCRIPTION
## Summary
- Add a dedicated 404 Not Found page with a torrent-themed design
- Implement catch-all route using Vue Router's `/:pathMatch(.*)*` pattern
- Display a spinning loader as the "0" in 404, with "no seeders" message
- Show mock torrent stats (0 seeders, 1 leecher) for humor
- Add "Back to home" button for easy navigation

## Changes
- `frontend/src/views/NotFoundView.vue` - New 404 page component
- `frontend/src/router/index.ts` - Add catch-all route
- `frontend/src/i18n/en.json` - Add translation keys

Closes #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a 404 "Page Not Found" page for unmatched URLs
  * Invalid page paths now display an error page with a link to return home

* **Localization**
  * Added English translations for error messages and navigation options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->