### PR TITLE
fix: prevent long text from overflowing bbcode container

### DIFF
--- a/frontend/src/components/community/BBCodeRenderer.vue
+++ b/frontend/src/components/community/BBCodeRenderer.vue
@@ -19,6 +19,7 @@ const parsedContent = computed(() => {
 .bbcode-content {
   width: 100%;
   overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .bbcode-content :deep(img) {


### PR DESCRIPTION
Add `word-break: break-word` to prevent long strings from overflowing.

Fixes #428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text wrapping in BBCode content to ensure long words and text display properly without overflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->