### PR TITLE
feat: invalidate JWT token in Redis on logout

### DIFF
--- a/backend/api/src/api_doc.rs
+++ b/backend/api/src/api_doc.rs
@@ -22,6 +22,7 @@ use crate::handlers::user_applications::get_user_applications::GetUserApplicatio
     paths(
         crate::handlers::auth::register::exec,
         crate::handlers::auth::login::exec,
+        crate::handlers::auth::logout::exec,
         crate::handlers::auth::refresh_token::exec,
         crate::handlers::users::get_user::exec,
         crate::handlers::users::edit_user::exec,

--- a/backend/api/src/handlers/auth/logout.rs
+++ b/backend/api/src/handlers/auth/logout.rs
@@ -1,0 +1,22 @@
+use crate::{middlewares::auth_middleware::Authdata, Arcadia};
+use actix_web::{web, HttpResponse};
+use arcadia_common::error::Result;
+use arcadia_storage::redis::RedisPoolInterface;
+
+#[utoipa::path(
+    post,
+    operation_id = "Logout",
+    tag = "Auth",
+    path = "/api/auth/logout",
+    responses(
+        (status = 200, description = "Successfully logged out"),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn exec<R: RedisPoolInterface + 'static>(
+    arc: web::Data<Arcadia<R>>,
+    auth: Authdata,
+) -> Result<HttpResponse> {
+    arc.auth.invalidate(auth.sub).await?;
+    Ok(HttpResponse::Ok().finish())
+}

--- a/backend/api/src/handlers/auth/mod.rs
+++ b/backend/api/src/handlers/auth/mod.rs
@@ -1,5 +1,6 @@
 pub mod create_user_application;
 pub mod login;
+pub mod logout;
 pub mod refresh_token;
 pub mod register;
 
@@ -9,6 +10,7 @@ use arcadia_storage::redis::RedisPoolInterface;
 pub fn config<R: RedisPoolInterface + 'static>(cfg: &mut ServiceConfig) {
     cfg.service(resource("/register").route(post().to(self::register::exec::<R>)));
     cfg.service(resource("/login").route(post().to(self::login::exec::<R>)));
+    cfg.service(resource("/logout").route(post().to(self::logout::exec::<R>)));
     cfg.service(resource("/refresh-token").route(post().to(self::refresh_token::exec::<R>)));
     cfg.service(resource("/apply").route(post().to(self::create_user_application::exec::<R>)));
 }

--- a/frontend/src/components/nav_menu/desktop/DesktopNavMenu.vue
+++ b/frontend/src/components/nav_menu/desktop/DesktopNavMenu.vue
@@ -42,6 +42,7 @@
 
 <script setup lang="ts">
 import { useUserStore } from '@/stores/user'
+import { logout } from '@/services/api-schema'
 import { Button } from 'primevue'
 import Popover from 'primevue/popover'
 import { useI18n } from 'vue-i18n'
@@ -72,8 +73,14 @@ const onLeaveUserIcon = () => {
   }, 100)
 }
 
-const handleLogout = () => {
+const handleLogout = async () => {
+  try {
+    await logout()
+  } catch {
+    // Ignore errors (token may already be expired)
+  }
   localStorage.removeItem('token')
+  localStorage.removeItem('refreshToken')
   localStorage.removeItem('user')
   user.removeUser()
   router.push('/login')

--- a/frontend/src/components/nav_menu/mobile/MobileNavMenu.vue
+++ b/frontend/src/components/nav_menu/mobile/MobileNavMenu.vue
@@ -45,6 +45,7 @@ import { Button, Divider, PanelMenu } from 'primevue'
 import router from '@/router'
 import { ref } from 'vue'
 import { useUserStore } from '@/stores/user'
+import { logout } from '@/services/api-schema'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
@@ -55,8 +56,14 @@ const onOpenMenu = () => {
   visible.value = true
 }
 
-const handleLogout = () => {
+const handleLogout = async () => {
+  try {
+    await logout()
+  } catch {
+    // Ignore errors (token may already be expired)
+  }
   localStorage.removeItem('token')
+  localStorage.removeItem('refreshToken')
   localStorage.removeItem('user')
   user.removeUser()
   router.push('/login')

--- a/frontend/src/services/api-schema/api.ts
+++ b/frontend/src/services/api-schema/api.ts
@@ -1578,6 +1578,7 @@ export interface UpdateUserApplication {
 export interface UploadInformation {
     'announce_url': string;
 }
+
 export interface UploadedTorrent {
     'audio_bitrate': number;
     'audio_bitrate_sampling': AudioBitrateSampling;
@@ -1601,7 +1602,6 @@ export interface UploadedTorrent {
     'video_resolution_other_x': number;
     'video_resolution_other_y': number;
 }
-
 
 export interface User {
     'artist_comments': number;
@@ -2396,6 +2396,35 @@ export const AuthApiAxiosParamCreator = function (configuration?: Configuration)
         },
         /**
          * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        logout: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/auth/logout`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {RefreshToken} refreshToken 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -2487,6 +2516,17 @@ export const AuthApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async logout(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logout(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['AuthApi.logout']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
          * @param {RefreshToken} refreshToken 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -2529,6 +2569,14 @@ export const AuthApiFactory = function (configuration?: Configuration, basePath?
         },
         /**
          * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        logout(options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.logout(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @param {RefreshToken} refreshToken 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -2564,6 +2612,15 @@ export class AuthApi extends BaseAPI {
 
     /**
      * 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public logout(options?: RawAxiosRequestConfig) {
+        return AuthApiFp(this.configuration).logout(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
      * @param {RefreshToken} refreshToken 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -2590,6 +2647,12 @@ export const authApi = new AuthApi(undefined, undefined, globalAxios);
 
 export const login = async (login: Login, options?: RawAxiosRequestConfig): Promise<LoginResponse> => {
     const response = await authApi.login(login, options);
+    return response.data;
+};
+
+
+export const logout = async (options?: RawAxiosRequestConfig): Promise<void> => {
+    const response = await authApi.logout(options);
     return response.data;
 };
 


### PR DESCRIPTION
## Summary

- Adds `POST /api/auth/logout` endpoint that invalidates the user's JWT token in Redis
- Frontend now calls the logout API before clearing localStorage
- Any token issued before logout is immediately rejected by the server

## Changes

**Backend:**
- New handler `backend/api/src/handlers/auth/logout.rs`
- Route registered in `mod.rs` and documented in `api_doc.rs`

**Frontend:**
- `DesktopNavMenu.vue` and `MobileNavMenu.vue` updated to call logout API
- Also removes `refreshToken` from localStorage (was missing before)

## Test plan

- [x] Login with valid credentials
- [x] Verify token works (call `/api/users/me`)
- [x] Logout
- [x] Verify same token is now rejected with "token for user invalidated"

Closes #452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added secure logout functionality with proper server-side session invalidation and complete client-side token cleanup, ensuring all authentication credentials are properly cleared upon user sign-out.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->