### PR TITLE
fix: frontend container tries to start before backend, ergo or kiwiirc

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -130,6 +130,13 @@ services:
     env_file:
       - frontend/.env.docker
       - frontend/.env
+    depends_on: # only start after the containers listed in nginx.conf
+      backend:
+        condition: service_started
+      ergo:
+        condition: service_started
+      kiwiirc:
+        condition: service_started 
     develop:
       watch:
         - path: ./frontend/dist


### PR DESCRIPTION
if the frontend container starts before backend, ergo or kiwi, their ip in the docker network can't be resolved and the container crashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service initialization configuration to ensure backend dependencies are fully started before the frontend application launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->