### PR TITLE
disable the key return for creation and editing title/edition/torrent

### DIFF
--- a/frontend/src/components/edition_group/CreateOrEditEditionGroup.vue
+++ b/frontend/src/components/edition_group/CreateOrEditEditionGroup.vue
@@ -5,6 +5,7 @@
     :initialValues="editionGroupForm"
     :resolver
     @submit="onFormSubmit"
+    @keydown.enter.prevent
     validateOnSubmit
     validateOnValueUpdate
     validateOnMount

--- a/frontend/src/components/edition_group/CreateOrEditEditionGroup.vue
+++ b/frontend/src/components/edition_group/CreateOrEditEditionGroup.vue
@@ -5,7 +5,7 @@
     :initialValues="editionGroupForm"
     :resolver
     @submit="onFormSubmit"
-    @keydown.enter.prevent
+    @keydown.enter="onFormKeydown"
     validateOnSubmit
     validateOnValueUpdate
     validateOnMount
@@ -160,7 +160,7 @@ import Message from 'primevue/message'
 import { Form, type FormResolverOptions, type FormSubmitEvent } from '@primevue/forms'
 import { Checkbox, InputNumber } from 'primevue'
 import { useI18n } from 'vue-i18n'
-import { getSources, isReleaseDateRequired, formatDateToLocalString, parseDateStringToLocal } from '@/services/helpers'
+import { getSources, isReleaseDateRequired, formatDateToLocalString, parseDateStringToLocal, onFormKeydown } from '@/services/helpers'
 import type { VNodeRef } from 'vue'
 import { useEditionGroupStore } from '@/stores/editionGroup'
 import type { ContentType, UserCreatedEditionGroup } from '@/services/api-schema'

--- a/frontend/src/components/title_group/CreateOrEditTitleGroup.vue
+++ b/frontend/src/components/title_group/CreateOrEditTitleGroup.vue
@@ -5,7 +5,7 @@
     :initialValues="titleGroupForm"
     :resolver
     @submit="sendTitleGroup"
-    @keydown.enter.prevent
+    @keydown.enter="onFormKeydown"
     validateOnSubmit
     validateOnValueUpdate
     validateOnBlur
@@ -256,6 +256,7 @@ import {
   isReleaseDateRequired,
   formatDateToLocalString,
   parseDateStringToLocal,
+  onFormKeydown,
 } from '@/services/helpers'
 import { useTitleGroupStore } from '@/stores/titleGroup'
 import { usePublicArcadiaSettingsStore } from '@/stores/publicArcadiaSettings'

--- a/frontend/src/components/title_group/CreateOrEditTitleGroup.vue
+++ b/frontend/src/components/title_group/CreateOrEditTitleGroup.vue
@@ -5,6 +5,7 @@
     :initialValues="titleGroupForm"
     :resolver
     @submit="sendTitleGroup"
+    @keydown.enter.prevent
     validateOnSubmit
     validateOnValueUpdate
     validateOnBlur

--- a/frontend/src/components/torrent/CreateOrEditTorrent.vue
+++ b/frontend/src/components/torrent/CreateOrEditTorrent.vue
@@ -5,7 +5,7 @@
     :initialValues="torrentForm"
     :resolver
     @submit="onFormSubmit"
-    @keydown.enter.prevent
+    @keydown.enter="onFormKeydown"
     validateOnSubmit
     validateOnValueUpdate
     validateOnBlur
@@ -329,6 +329,7 @@ import {
   isAttributeUsed,
   rawToDisplayBp,
   displayToRawBp,
+  onFormKeydown,
 } from '@/services/helpers'
 import { useEditionGroupStore } from '@/stores/editionGroup'
 import { uploadTorrent } from '@/services/api/torrentService'

--- a/frontend/src/components/torrent/CreateOrEditTorrent.vue
+++ b/frontend/src/components/torrent/CreateOrEditTorrent.vue
@@ -5,6 +5,7 @@
     :initialValues="torrentForm"
     :resolver
     @submit="onFormSubmit"
+    @keydown.enter.prevent
     validateOnSubmit
     validateOnValueUpdate
     validateOnBlur

--- a/frontend/src/services/helpers.ts
+++ b/frontend/src/services/helpers.ts
@@ -427,3 +427,17 @@ export const formatDateTimeLabel = (period: string, interval: StatsInterval): st
   }
   return date.toLocaleString('default', periodFormatOptions[interval])
 }
+
+/**
+ * Handle keydown events on a form and prevent implicit submit when the return key is pressed
+ * Only use via @keydown.enter for now
+ * @param {KeyboardEvent} event The keyboard event emmited by the form
+ *
+ */
+export const onFormKeydown = (event: KeyboardEvent) => {
+  const target = event.target
+
+  if (target instanceof HTMLInputElement && !['button', 'submit', 'reset', 'checkbox', 'radio', 'file'].includes(target.type)) {
+    event.preventDefault()
+  }
+}


### PR DESCRIPTION
Closes #476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated form behavior in edition group, title group, and torrent editors to better handle Enter key presses within input fields across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->