### PR TITLE
docs(docs/src/run-standard.md): Add systemd unit config example

### DIFF
--- a/docs/src/run-standard.md
+++ b/docs/src/run-standard.md
@@ -252,14 +252,14 @@ After=network.target arcadia-tracker.service arcadia-api.service
 User=USER_TO_RUN_AS
 Group=GROUP_TO_RUN_AS
 Type=simple
-TimeoutStopSec=5
+TimeoutStopSec=10
 WorkingDirectory=PATH_TO_THE_ARCADIA_FRONTEND_DIR
 
 ExecReload=/usr/bin/npm run build
 
 ExecStart=/usr/bin/npm run dev -- --host
 
-ExecStop=/bin/kill -s SIGINT $MAINPID
+KillSignal=SIGINT
 
 [Install]
 WantedBy=multi-user.target
@@ -280,14 +280,14 @@ After=network.target postgresql.service
 User=USER_TO_RUN_AS
 Group=GROUP_TO_RUN_AS
 Type=simple
-TimeoutStopSec=5
+TimeoutStopSec=10
 WorkingDirectory=PATH_TO_THE_ARCADIA_TRACKER_DIR
 
 ExecReload=/home/on/.cargo/bin/cargo build --release
 
 ExecStart=/home/on/.cargo/bin/cargo run --release
 
-ExecStop=/bin/kill -s SIGINT $MAINPID
+KillSignal=SIGINT
 
 [Install]
 WantedBy=multi-user.target
@@ -315,7 +315,7 @@ ExecReload=/home/on/.cargo/bin/cargo build --release
 
 ExecStart=/home/on/.cargo/bin/cargo run --release
 
-ExecStop=/bin/kill -s SIGINT $MAINPID
+KillSignal=SIGINT
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/src/run-standard.md
+++ b/docs/src/run-standard.md
@@ -283,9 +283,9 @@ Type=simple
 TimeoutStopSec=10
 WorkingDirectory=PATH_TO_THE_ARCADIA_TRACKER_DIR
 
-ExecReload=/home/on/.cargo/bin/cargo build --release
+ExecReload=PATH_TO_THE_CARGO_BIN build --release
 
-ExecStart=/home/on/.cargo/bin/cargo run --release
+ExecStart=PATH_TO_THE_CARGO_BIN run --release
 
 KillSignal=SIGINT
 
@@ -293,7 +293,7 @@ KillSignal=SIGINT
 WantedBy=multi-user.target
 ```
 
-<ins>**NOTE**</ins>: Don't forget to change `USER_TO_RUN_AS`, `GROUP_TO_RUN_AS` and `PATH_TO_THE_ARCADIA_TRACKER_DIR` to the correct value.
+<ins>**NOTE**</ins>: Don't forget to change `USER_TO_RUN_AS`, `GROUP_TO_RUN_AS`, `PATH_TO_THE_ARCADIA_TRACKER_DIR` and `PATH_TO_THE_CARGO_BIN` to the correct value.
 
 ### For the API
 
@@ -311,9 +311,9 @@ Type=simple
 TimeoutStopSec=10
 WorkingDirectory=PATH_TO_THE_ARCADIA_API_DIR
 
-ExecReload=/home/on/.cargo/bin/cargo build --release
+ExecReload=PATH_TO_THE_CARGO_BIN build --release
 
-ExecStart=/home/on/.cargo/bin/cargo run --release
+ExecStart=PATH_TO_THE_CARGO_BIN run --release
 
 KillSignal=SIGINT
 
@@ -321,7 +321,7 @@ KillSignal=SIGINT
 WantedBy=multi-user.target
 ```
 
-<ins>**NOTE**</ins>: Don't forget to change `USER_TO_RUN_AS`, `GROUP_TO_RUN_AS` and `PATH_TO_THE_ARCADIA_API_DIR` to the correct value.
+<ins>**NOTE**</ins>: Don't forget to change `USER_TO_RUN_AS`, `GROUP_TO_RUN_AS`, `PATH_TO_THE_ARCADIA_API_DIR` and `PATH_TO_THE_CARGO_BIN` to the correct value.
 
 ### Enable them
 

--- a/docs/src/run-standard.md
+++ b/docs/src/run-standard.md
@@ -234,3 +234,100 @@ To stop Arcadia:
 2. Stop the tracker with `Ctrl+C` in its terminal and wait for its graceful shutdown
 3. Stop the backend API with `Ctrl+C` in its terminal
 4. Optionally stop PostgreSQL if you don't need it for other applications
+
+## Systemd unit
+
+If you want to run Arcadia via systemd to have feature like auto start on boot, you can use these systemd unit file below.
+
+### For the frontend
+
+Copy the following below and paste it in  `/etc/systemd/system/arcadia-frontend.service`:
+
+```text
+[Unit]
+Description=Arcadia frontend
+After=network.target arcadia-tracker.service arcadia-api.service
+
+[Service]
+User=USER_TO_RUN_AS
+Group=GROUP_TO_RUN_AS
+Type=simple
+TimeoutStopSec=5
+WorkingDirectory=PATH_TO_THE_ARCADIA_FRONTEND_DIR
+
+ExecReload=/usr/bin/npm run build
+
+ExecStart=/usr/bin/npm run dev -- --host
+
+ExecStop=/bin/kill -s SIGINT $MAINPI
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target
+```
+
+<ins>**NOTE**</ins>: Don't forget to change `USER_TO_RUN_AS`, `GROUP_TO_RUN_AS` and `PATH_TO_THE_ARCADIA_FRONTEND_DIR` to the correct value.
+
+### For the tracker
+
+Copy the following below and paste it in `/etc/systemd/system/arcadia-tracker.service`:
+
+```text
+[Unit]
+Description=Arcadia backend tracker
+After=network.target postgresql.service
+
+[Service]
+User=USER_TO_RUN_AS
+Group=GROUP_TO_RUN_AS
+Type=simple
+TimeoutStopSec=5
+WorkingDirectory=PATH_TO_THE_ARCADIA_TRACKER_DIR
+
+ExecReload=/home/on/.cargo/bin/cargo build --release
+
+ExecStart=/home/on/.cargo/bin/cargo run --release
+
+ExecStop=/bin/kill -s SIGINT $MAINPID
+
+[Install]
+WantedBy=multi-user.target
+```
+
+<ins>**NOTE**</ins>: Don't forget to change `USER_TO_RUN_AS`, `GROUP_TO_RUN_AS` and `PATH_TO_THE_ARCADIA_TRACKER_DIR` to the correct value.
+
+### For the API
+
+Copy the following below and paste it in `/etc/systemd/system/arcadia-api.service`:
+
+```text
+[Unit]
+Description=Arcadia backend API
+After=network.target arcadia-tracker.service postgresql.service
+
+[Service]
+User=USER_TO_RUN_AS
+Group=GROUP_TO_RUN_AS
+Type=simple
+TimeoutStopSec=10
+WorkingDirectory=PATH_TO_THE_ARCADIA_API_DIR
+
+ExecReload=/home/on/.cargo/bin/cargo build --release
+
+ExecStart=/home/on/.cargo/bin/cargo run --release
+
+ExecStop=/bin/kill -s SIGINT $MAINPID
+
+[Install]
+WantedBy=multi-user.target
+```
+
+<ins>**NOTE**</ins>: Don't forget to change `USER_TO_RUN_AS`, `GROUP_TO_RUN_AS` and `PATH_TO_THE_ARCADIA_API_DIR` to the correct value.
+
+### Enable them
+
+Enable them so they will auto-start on boot:
+
+```bash
+systemctl enable arcadia-frontend.service arcadia-tracker.service arcadia-api.service
+```

--- a/docs/src/run-standard.md
+++ b/docs/src/run-standard.md
@@ -259,8 +259,7 @@ ExecReload=/usr/bin/npm run build
 
 ExecStart=/usr/bin/npm run dev -- --host
 
-ExecStop=/bin/kill -s SIGINT $MAINPI
-KillSignal=SIGINT
+ExecStop=/bin/kill -s SIGINT $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/src/run-standard.md
+++ b/docs/src/run-standard.md
@@ -328,5 +328,5 @@ WantedBy=multi-user.target
 Enable them so they will auto-start on boot:
 
 ```bash
-systemctl enable arcadia-frontend.service arcadia-tracker.service arcadia-api.service
+sudo systemctl enable arcadia-frontend.service arcadia-tracker.service arcadia-api.service
 ```


### PR DESCRIPTION
Added an systemd unit config file for power users that want to control Arcadia via systemd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added systemd deployment instructions for the frontend, tracker, and API services.
  * Documented service configuration, dependencies, working directories, and lifecycle commands.
  * Added guidance for replacing placeholder values and enabling services to start automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->